### PR TITLE
Fix `if_setevents` property

### DIFF
--- a/transcriber/transcriber-223/transcriber-223-base/src/main/kotlin/net/rsprox/transcriber/base/impl/BaseServerPacketTranscriber.kt
+++ b/transcriber/transcriber-223/transcriber-223-base/src/main/kotlin/net/rsprox/transcriber/base/impl/BaseServerPacketTranscriber.kt
@@ -1060,7 +1060,7 @@ public class BaseServerPacketTranscriber(
         if (!filters[PropertyFilter.IF_SETEVENTS]) return omit()
         root.com(message.interfaceId, message.componentId)
         root.int("start", message.start.maxUShortToMinusOne())
-        root.int("end", message.start.maxUShortToMinusOne())
+        root.int("end", message.end.maxUShortToMinusOne())
         root.string("events", EventMask.list(message.events).toString())
     }
 


### PR DESCRIPTION
Fixes typo in `BaseServerPacketTranscriber.ifSetEvents` for the "end" property.