### PR TITLE
Add ability to resolve multinpc types

### DIFF
--- a/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/type/VarBitType.kt
+++ b/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/type/VarBitType.kt
@@ -11,6 +11,12 @@ public interface VarBitType {
         return BITMASKS[bitcount]
     }
 
+    public fun extract(packedInteger: Int): Int {
+        val bitcount = (endbit - startbit) + 1
+        val bitmask = bitmask(bitcount)
+        return packedInteger ushr startbit and bitmask
+    }
+
     private companion object {
         private val BITMASKS: IntArray = generateBitmasks()
 

--- a/cache/src/main/kotlin/net/rsprox/cache/OldSchoolCache.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/OldSchoolCache.kt
@@ -80,7 +80,7 @@ public class OldSchoolCache(
     }
 
     private fun resolveVarBits() {
-        check(!this::npcs.isInitialized) {
+        check(!this::varbits.isInitialized) {
             "VarBits already initialized."
         }
         try {

--- a/transcriber/transcriber-223/transcriber-223-base/src/main/kotlin/net/rsprox/transcriber/base/BaseTranscriber.kt
+++ b/transcriber/transcriber-223/transcriber-223-base/src/main/kotlin/net/rsprox/transcriber/base/BaseTranscriber.kt
@@ -29,6 +29,7 @@ public class BaseTranscriber private constructor(
 ) : Transcriber,
     ClientPacketTranscriber by BaseClientPacketTranscriber(
         stateTracker,
+        cacheProvider.get(),
         filterSetStore,
     ),
     ServerPacketTranscriber by BaseServerPacketTranscriber(
@@ -39,6 +40,7 @@ public class BaseTranscriber private constructor(
     PlayerInfoTranscriber by BasePlayerInfoTranscriber(
         stateTracker,
         monitor,
+        cacheProvider.get(),
         filterSetStore,
     ),
     NpcInfoTranscriber by BaseNpcInfoTranscriber(

--- a/transcriber/transcriber-223/transcriber-223-base/src/main/kotlin/net/rsprox/transcriber/base/impl/BaseNpcInfoTranscriber.kt
+++ b/transcriber/transcriber-223/transcriber-223-base/src/main/kotlin/net/rsprox/transcriber/base/impl/BaseNpcInfoTranscriber.kt
@@ -79,25 +79,23 @@ public class BaseNpcInfoTranscriber(
     }
 
     private fun Property.npc(index: Int): ChildProperty<*> {
-        val npc = stateTracker.getActiveWorld().getNpcOrNull(index)
+        val world = stateTracker.getActiveWorld()
+        val npc = world.getNpcOrNull(index) ?: return unidentifiedNpc(index)
         val finalIndex =
             if (filters[PropertyFilter.NPC_OMIT_INDEX]) {
                 Int.MIN_VALUE
             } else {
                 index
             }
-        return if (npc != null) {
-            identifiedNpc(
-                finalIndex,
-                npc.id,
-                npc.name ?: "null",
-                npc.coord.level,
-                npc.coord.x,
-                npc.coord.z,
-            )
-        } else {
-            unidentifiedNpc(index)
-        }
+        val multinpc = stateTracker.resolveMultinpc(npc.id, cache)
+        return identifiedNpc(
+            finalIndex,
+            npc.id,
+            multinpc?.name ?: npc.name ?: "null",
+            npc.coord.level,
+            npc.coord.x,
+            npc.coord.z,
+        )
     }
 
     private fun Property.shortNpc(

--- a/transcriber/transcriber-223/transcriber-223-base/src/main/kotlin/net/rsprox/transcriber/base/impl/BaseServerPacketTranscriber.kt
+++ b/transcriber/transcriber-223/transcriber-223-base/src/main/kotlin/net/rsprox/transcriber/base/impl/BaseServerPacketTranscriber.kt
@@ -202,25 +202,23 @@ public class BaseServerPacketTranscriber(
     }
 
     private fun Property.npc(index: Int): ChildProperty<*> {
-        val npc = stateTracker.getActiveWorld().getNpcOrNull(index)
+        val world = stateTracker.getActiveWorld()
+        val npc = world.getNpcOrNull(index) ?: return unidentifiedNpc(index)
         val finalIndex =
             if (filters[PropertyFilter.NPC_OMIT_INDEX]) {
                 Int.MIN_VALUE
             } else {
                 index
             }
-        return if (npc != null) {
-            identifiedNpc(
-                finalIndex,
-                npc.id,
-                npc.name ?: "null",
-                npc.coord.level,
-                npc.coord.x,
-                npc.coord.z,
-            )
-        } else {
-            unidentifiedNpc(index)
-        }
+        val multinpc = stateTracker.resolveMultinpc(npc.id, cache)
+        return identifiedNpc(
+            finalIndex,
+            npc.id,
+            multinpc?.name ?: npc.name ?: "null",
+            npc.coord.level,
+            npc.coord.x,
+            npc.coord.z,
+        )
     }
 
     private fun Property.player(


### PR DESCRIPTION
NPCs with multinpc configs were hard to spot in the logs as their base types did not have display names. This feature gives the ability to resolve the corresponding multinpc based on the client/observer's var state. (both varplayers and varbits)
Some notes:
- We need to separate the `default` multinpc from the `multinpc` list. Ex: npc is meant to _only_ be visible when varbit is 10. This npc only has the aforementioned multinpc, and no `default` multinpc. Player's varbit is not 10. However, the last element is now treated as the default, so that is what they would 'observe.' Currently, there is no way to determine whether the last element in `multinpc` is the `default` multinpc.
- `getImpactedVarbits` in both IndexerTranscriber and BaseServerPacketTranscriber could switch to calling `VarBiType.extract.` This _does_ mean `bitcount` and `bitmask` values would be calculated twice (once for `oldValue` and once for `newValue`), so have left it up to discretion on whether that is done or not.
- Not sure if we want to extend this support for multinpc onto `shortNpc.` Given this function would usually mean that granular detail on npcs is not wanted.