### PR TITLE
fix: use continue instead of return when transcribing player info

### DIFF
--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextPlayerInfoTranscriber.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextPlayerInfoTranscriber.kt
@@ -186,7 +186,7 @@ public class TextPlayerInfoTranscriber(
                         }
                         is PlayerUpdateType.HighResolutionIdle -> {
                             if (update.extendedInfo.isEmpty()) {
-                                return@group
+                                continue
                             }
                             val player = sessionState.getPlayer(index)
                             group("IDLE") {


### PR DESCRIPTION
This was making player info exit a lot earlier and omitting a lot of information.