### PR TITLE
Add `CONVERT_COORD_TO_JAGCOORD` setting

### DIFF
--- a/shared/src/main/kotlin/net/rsprox/shared/property/NopSymbolDictionary.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/NopSymbolDictionary.kt
@@ -1,0 +1,3 @@
+package net.rsprox.shared.property
+
+public object NopSymbolDictionary : SymbolDictionary by SymbolDictionary.EMPTY_SYMBOL_DICTIONARY

--- a/shared/src/main/kotlin/net/rsprox/shared/property/PropertyExtensions.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/PropertyExtensions.kt
@@ -582,3 +582,16 @@ public fun Property.unidentifiedWorldEntity(
         ),
     )
 }
+
+internal fun toJagCoords(level: Int, x: Int, z: Int): List<Int> {
+    val mx = x / 64
+    val mz = z / 64
+    val lx = x % 64
+    val lz = z % 64
+    return listOf(level, mx, mz, lx, lz)
+}
+
+internal fun toJagCoordsText(level: Int, x: Int, z: Int): String {
+    val (lvl, mx, mz, lx, lz) = toJagCoords(level, x, z)
+    return "${lvl}_${mx}_${mz}_${lx}_${lz}"
+}

--- a/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedChildProperty.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedChildProperty.kt
@@ -1,0 +1,23 @@
+package net.rsprox.shared.property.regular
+
+import net.rsprox.shared.property.ChildProperty
+import net.rsprox.shared.property.NopSymbolDictionary
+import net.rsprox.shared.property.SymbolDictionary
+import net.rsprox.shared.settings.NopSettingSet
+import net.rsprox.shared.settings.SettingSet
+
+public sealed class IdentifiedChildProperty(
+    override val propertyName: String,
+    public val index: Int,
+    public val level: Int,
+    public val x: Int,
+    public val z: Int,
+) : ChildProperty<String> {
+    override val children: MutableList<ChildProperty<*>> = mutableListOf()
+
+    override val type: Class<String> = String::class.java
+
+    override val value: String = formattedValue(NopSettingSet, NopSymbolDictionary)
+
+    public abstract fun formattedValue(settings: SettingSet, dictionary: SymbolDictionary): String
+}

--- a/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedMultinpcProperty.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedMultinpcProperty.kt
@@ -1,22 +1,61 @@
 package net.rsprox.shared.property.regular
 
-import net.rsprox.shared.property.ChildProperty
+import net.rsprox.shared.ScriptVarType
+import net.rsprox.shared.property.SymbolDictionary
+import net.rsprox.shared.property.toJagCoordsText
+import net.rsprox.shared.settings.Setting
+import net.rsprox.shared.settings.SettingSet
 
 public class IdentifiedMultinpcProperty(
     override val propertyName: String,
-    public val index: Int,
+    index: Int,
     public val baseId: Int,
     public val multinpcId: Int,
     public val npcName: String,
-    public val level: Int,
-    public val x: Int,
-    public val z: Int,
-    override val value: String =
-        if (index == Int.MIN_VALUE) {
-            "(name=$npcName, coord=($x, $z, $level))"
+    level: Int,
+    x: Int,
+    z: Int,
+) : IdentifiedChildProperty(propertyName, index, level, x, z) {
+    override fun formattedValue(settings: SettingSet, dictionary: SymbolDictionary): String = buildString {
+        append('(')
+
+        if (index != Int.MIN_VALUE) {
+            append("index=$index, ")
+        }
+
+        val baseSymbol = dictionary.getScriptVarTypeName(baseId, ScriptVarType.NPC)
+        if (baseSymbol != null) {
+            append("id=$baseSymbol")
+            if (settings[Setting.SHOW_IDS_AFTER_SYMBOLS]) {
+                append(" ($baseId)")
+            }
         } else {
-            "(index=$index, name=$npcName, coord=($x, $z, $level))"
-        },
-    override val children: MutableList<ChildProperty<*>> = mutableListOf(),
-    override val type: Class<String> = String::class.java,
-) : ChildProperty<String>
+            append("id=$baseId")
+        }
+
+        append(", ")
+
+        val multiSymbol = dictionary.getScriptVarTypeName(multinpcId, ScriptVarType.NPC)
+        if (multiSymbol != null) {
+            append("multinpc=$multiSymbol")
+            if (settings[Setting.SHOW_IDS_AFTER_SYMBOLS]) {
+                append(" ($multinpcId)")
+            }
+        } else if (npcName != "null") {
+            append("multinpc=$npcName (id=$multinpcId)")
+        } else {
+            append("multinpc=$baseId")
+        }
+
+        append(", ")
+
+        if (settings[Setting.CONVERT_COORD_TO_JAGCOORD]) {
+            val formatted = toJagCoordsText(level, x, z)
+            append("coord=($formatted)")
+        } else {
+            append("coord=($x, $z, $level)")
+        }
+
+        append(')')
+    }
+}

--- a/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedNpcProperty.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedNpcProperty.kt
@@ -1,21 +1,48 @@
 package net.rsprox.shared.property.regular
 
-import net.rsprox.shared.property.ChildProperty
+import net.rsprox.shared.ScriptVarType
+import net.rsprox.shared.property.SymbolDictionary
+import net.rsprox.shared.property.toJagCoordsText
+import net.rsprox.shared.settings.Setting
+import net.rsprox.shared.settings.SettingSet
 
 public class IdentifiedNpcProperty(
     override val propertyName: String,
-    public val index: Int,
+    index: Int,
     public val id: Int,
     public val npcName: String,
-    public val level: Int,
-    public val x: Int,
-    public val z: Int,
-    override val value: String =
-        if (index == Int.MIN_VALUE) {
-            "(name=$npcName, coord=($x, $z, $level))"
+    level: Int,
+    x: Int,
+    z: Int,
+) : IdentifiedChildProperty(propertyName, index, level, x, z) {
+    override fun formattedValue(settings: SettingSet, dictionary: SymbolDictionary): String = buildString {
+        append('(')
+
+        if (index != Int.MIN_VALUE) {
+            append("index=$index, ")
+        }
+
+        val symbol = dictionary.getScriptVarTypeName(id, ScriptVarType.NPC)
+        if (symbol != null) {
+            append("id=$symbol")
+            if (settings[Setting.SHOW_IDS_AFTER_SYMBOLS]) {
+                append(" ($id)")
+            }
+        } else if (npcName != "null") {
+            append("$npcName (id=$id)")
         } else {
-            "(index=$index, name=$npcName, coord=($x, $z, $level))"
-        },
-    override val children: MutableList<ChildProperty<*>> = mutableListOf(),
-    override val type: Class<String> = String::class.java,
-) : ChildProperty<String>
+            append("id=$id")
+        }
+
+        append(", ")
+
+        if (settings[Setting.CONVERT_COORD_TO_JAGCOORD]) {
+            val formatted = toJagCoordsText(level, x, z)
+            append("coord=($formatted)")
+        } else {
+            append("coord=($x, $z, $level)")
+        }
+
+        append(')')
+    }
+}

--- a/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedPlayerProperty.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedPlayerProperty.kt
@@ -1,20 +1,34 @@
 package net.rsprox.shared.property.regular
 
-import net.rsprox.shared.property.ChildProperty
+import net.rsprox.shared.property.SymbolDictionary
+import net.rsprox.shared.property.toJagCoordsText
+import net.rsprox.shared.settings.Setting
+import net.rsprox.shared.settings.SettingSet
 
 public class IdentifiedPlayerProperty(
     override val propertyName: String,
-    public val index: Int,
+    index: Int,
     public val playerName: String,
-    public val level: Int,
-    public val x: Int,
-    public val z: Int,
-    override val value: String =
-        if (index == Int.MIN_VALUE) {
-            "(name=$playerName, coord=($x, $z, $level))"
+    level: Int,
+    x: Int,
+    z: Int,
+) : IdentifiedChildProperty(propertyName, index, level, x, z) {
+    override fun formattedValue(settings: SettingSet, dictionary: SymbolDictionary): String = buildString {
+        append('(')
+
+        if (index != Int.MIN_VALUE) {
+            append("index=$index, ")
+        }
+
+        append("name=$playerName, ")
+
+        if (settings[Setting.CONVERT_COORD_TO_JAGCOORD]) {
+            val formatted = toJagCoordsText(level, x, z)
+            append("coord=($formatted)")
         } else {
-            "(index=$index, name=$playerName, coord=($x, $z, $level))"
-        },
-    override val children: MutableList<ChildProperty<*>> = mutableListOf(),
-    override val type: Class<String> = String::class.java,
-) : ChildProperty<String>
+            append("coord=($x, $z, $level)")
+        }
+
+        append(')')
+    }
+}

--- a/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedWorldEntityProperty.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedWorldEntityProperty.kt
@@ -1,25 +1,39 @@
 package net.rsprox.shared.property.regular
 
-import net.rsprox.shared.property.ChildProperty
+import net.rsprox.shared.property.SymbolDictionary
+import net.rsprox.shared.property.toJagCoordsText
+import net.rsprox.shared.settings.Setting
+import net.rsprox.shared.settings.SettingSet
 
 public class IdentifiedWorldEntityProperty(
     override val propertyName: String,
-    public val index: Int,
-    public val level: Int,
-    public val x: Int,
-    public val z: Int,
-    sizeX: Int,
-    sizeZ: Int,
-    centerFineOffsetX: Int?,
-    centerFineOffsetZ: Int?,
-    override val children: MutableList<ChildProperty<*>> = mutableListOf(),
-    override val type: Class<String> = String::class.java,
-) : ChildProperty<String> {
-    override val value: String =
-        if (centerFineOffsetX != null && centerFineOffsetZ != null) {
-            "(index=$index, coord=($x, $z, $level), " +
-                "sizex=$sizeX, sizez=$sizeZ, offsetx=$centerFineOffsetX, offsetz=$centerFineOffsetZ)"
+    index: Int,
+    level: Int,
+    x: Int,
+    z: Int,
+    public val sizeX: Int,
+    public val sizeZ: Int,
+    public val centerFineOffsetX: Int?,
+    public val centerFineOffsetZ: Int?,
+) : IdentifiedChildProperty(propertyName, index, level, x, z) {
+    override fun formattedValue(settings: SettingSet, dictionary: SymbolDictionary): String = buildString {
+        append('(')
+
+        append("index=$index, ")
+
+        if (settings[Setting.CONVERT_COORD_TO_JAGCOORD]) {
+            val formatted = toJagCoordsText(level, x, z)
+            append("coord=($formatted)")
         } else {
-            "(index=$index, coord=($x, $z, $level), sizex=$sizeX, sizez=$sizeZ)"
+            append("coord=($x, $z, $level)")
         }
+
+        append("sizex=$sizeX, sizez=$sizeZ")
+
+        if (centerFineOffsetX != null && centerFineOffsetZ != null) {
+            append(", offsetx=$centerFineOffsetX, offsetz=$centerFineOffsetZ")
+        }
+
+        append(')')
+    }
 }

--- a/shared/src/main/kotlin/net/rsprox/shared/settings/NopSettingSet.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/settings/NopSettingSet.kt
@@ -1,0 +1,39 @@
+package net.rsprox.shared.settings
+
+public object NopSettingSet : SettingSet {
+    override fun getCreationTime(): Long = throw UnsupportedOperationException()
+
+    override fun getName(): String = throw UnsupportedOperationException()
+
+    override fun setName(name: String){
+        throw UnsupportedOperationException()
+    }
+
+    override fun deleteBackingFile() {
+        throw UnsupportedOperationException()
+    }
+
+    override fun get(setting: Setting): Boolean {
+        return false
+    }
+
+    override fun set(setting: Setting, enabled: Boolean) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun set(category: SettingCategory, enabled: Boolean) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun set(group: SettingGroup, enabled: Boolean) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setAll(enabled: Boolean) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setDefaults() {
+        throw UnsupportedOperationException()
+    }
+}

--- a/shared/src/main/kotlin/net/rsprox/shared/settings/Setting.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/settings/Setting.kt
@@ -27,7 +27,7 @@ public enum class Setting(
         SettingCategory.PREFS,
         "Convert to Jag Coords",
         false,
-        "Translates coords to the Jag format, e.g. (3200, 3200, 0) -> (0, 50, 50, 0, 0)",
+        "Translates coords to the Jag format, e.g. (3200, 3200, 0) -> (0_50_50_0_0)",
     ),
     TRANSLATE_INSTANCED_COORDS(
         SettingGroup.LOGGING,

--- a/shared/src/main/kotlin/net/rsprox/shared/settings/Setting.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/settings/Setting.kt
@@ -22,6 +22,13 @@ public enum class Setting(
         "When enabled and a symbol dictionary is provided, " +
             "will show ids after symbol names, e.g. \"armadyl_godsword (11802)\"",
     ),
+    CONVERT_COORD_TO_JAGCOORD(
+        SettingGroup.LOGGING,
+        SettingCategory.PREFS,
+        "Convert to Jag Coords",
+        false,
+        "Translates coords to the Jag format, e.g. (3200, 3200, 0) -> (0, 50, 50, 0, 0)",
+    ),
     TRANSLATE_INSTANCED_COORDS(
         SettingGroup.LOGGING,
         SettingCategory.MISC,


### PR DESCRIPTION
**Before**
![Before](https://i.imgur.com/v4bm3k4.png)

**After**
![After](https://i.imgur.com/6IiZH8r.png)

- Adds `IdentifiedChildProperty` as a base class for identified entity properties.

- Each `IdentifiedChildProperty` has its own `formattedValue` function, which takes in a `SettingSet` and `SymbolDictionary` to allow for flexibility and future maintainability.

- Replaces the old `PropertyFormatterCollection` npc property formatters.

- Adds a `NopSettingSet` and `NopSymbolDictionary` to maintain consistency with the old `value` property each of these new `IdentifiedChildProperty`s previously had. These nop variants are not used anywhere outside the `value` assignment.

- Adds the `Setting.CONVERT_COORD_TO_JAGCOORD` set to disabled by default.