### PR TITLE
Cache GameVal Loading

### DIFF
--- a/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/Cache.kt
+++ b/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/Cache.kt
@@ -1,5 +1,7 @@
 package net.rsprox.cache.api
 
+import net.rsprox.cache.api.type.GameVal
+import net.rsprox.cache.api.type.GameValType
 import net.rsprox.cache.api.type.NpcType
 import net.rsprox.cache.api.type.VarBitType
 
@@ -11,4 +13,11 @@ public interface Cache {
     public fun getVarBitType(id: Int): VarBitType?
 
     public fun listVarBitTypes(): Collection<VarBitType>
+
+    public fun getGameValType(
+        gameVal: GameVal,
+        id: Int,
+    ): GameValType?
+
+    public fun listGameValTypes(gameVal: GameVal): Collection<GameValType>
 }

--- a/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/Cache.kt
+++ b/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/Cache.kt
@@ -20,4 +20,6 @@ public interface Cache {
     ): GameValType?
 
     public fun listGameValTypes(gameVal: GameVal): Collection<GameValType>
+
+    public fun allGameValTypes(): Map<GameVal, Map<Int, GameValType>>
 }

--- a/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/type/GameVal.kt
+++ b/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/type/GameVal.kt
@@ -1,0 +1,15 @@
+package net.rsprox.cache.api.type
+
+public enum class GameVal {
+    IF_TYPE,
+    INV_TYPE,
+    LOC_TYPE,
+    NPC_TYPE,
+    OBJ_TYPE,
+    ROW_TYPE,
+    SEQ_TYPE,
+    SPOT_TYPE,
+    TABLE_TYPE,
+    VARBIT_TYPE,
+    VARP_TYPE,
+}

--- a/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/type/GameValType.kt
+++ b/cache/cache-api/src/main/kotlin/net/rsprox/cache/api/type/GameValType.kt
@@ -1,0 +1,22 @@
+package net.rsprox.cache.api.type
+
+public interface GameValType {
+    public val gameVal: GameVal
+    public val id: Int
+
+    public fun getParent(): String {
+        return checkNotNull(getParentOrNull()) {
+            "Parent is null for $gameVal:$id"
+        }
+    }
+
+    public fun getChild(childId: Int): String? {
+        return checkNotNull(getChildOrNull(childId)) {
+            "Child is null for $gameVal:$id:$childId"
+        }
+    }
+
+    public fun getParentOrNull(): String?
+
+    public fun getChildOrNull(childId: Int): String?
+}

--- a/cache/src/main/kotlin/net/rsprox/cache/OldSchoolCache.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/OldSchoolCache.kt
@@ -100,6 +100,13 @@ public class OldSchoolCache(
         return gameVals[gameVal]?.values ?: emptyList()
     }
 
+    override fun allGameValTypes(): Map<GameVal, Map<Int, GameValType>> {
+        if (!this::gameVals.isInitialized) {
+            resolveGameVals()
+        }
+        return this.gameVals
+    }
+
     private fun resolveGameVals() {
         check(!this::gameVals.isInitialized) {
             "Game vals already initialized."
@@ -211,6 +218,23 @@ public class OldSchoolCache(
             indexBuf.release()
             groupBuf.release()
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as OldSchoolCache
+
+        return masterIndex == other.masterIndex
+    }
+
+    override fun hashCode(): Int {
+        return masterIndex.hashCode()
+    }
+
+    override fun toString(): String {
+        return "OldSchoolCache(masterIndex=$masterIndex)"
     }
 
     private companion object {

--- a/cache/src/main/kotlin/net/rsprox/cache/live/Js5Decoder.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/live/Js5Decoder.kt
@@ -92,7 +92,7 @@ internal class Js5Decoder(
                     throw DecoderException("Invalid block trailer")
                 }
             }
-            this.downloader.groupResponse(this.response)
+            this.downloader.groupResponse(this.archive, this.group, this.response)
             this.state = State.RESPONSE_HEADER
         }
     }

--- a/cache/src/main/kotlin/net/rsprox/cache/live/Js5GroupDownloader.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/live/Js5GroupDownloader.kt
@@ -11,6 +11,7 @@ import net.rsprot.buffer.JagByteBuf
 import net.rsprot.buffer.extensions.toByteArray
 import net.rsprot.buffer.extensions.toJagByteBuf
 import net.rsprox.cache.Js5MasterIndex
+import net.rsprox.cache.util.CacheGroupRequest
 
 /**
  * A sequential blocking JS5 group downloader. This is not intended for downloading full caches,
@@ -25,7 +26,7 @@ public class Js5GroupDownloader internal constructor(
     private lateinit var bootstrap: Bootstrap
     private lateinit var channel: Channel
     private var connectionStatus: Int = CONNECTION_STATUS_UNINITIALIZED
-    private var response: ByteBuf? = null
+    private val responses: MutableMap<Int, ByteBuf> = mutableMapOf()
 
     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     private val lock: Object = Object()
@@ -66,7 +67,7 @@ public class Js5GroupDownloader internal constructor(
             buffer.p4(key)
         }
         logger.debug { "Writing JS5 remote connection" }
-        write(buffer)
+        writeAndFlush(buffer)
         logger.debug { "Awaiting JS5 remote connection response" }
         await()
         logger.debug { "JS5 remote connection response received: ${this.connectionStatus}" }
@@ -94,15 +95,27 @@ public class Js5GroupDownloader internal constructor(
         }
     }
 
-    internal fun groupResponse(buffer: ByteBuf) {
-        this.response = buffer
+    internal fun groupResponse(
+        archive: Int,
+        group: Int,
+        buffer: ByteBuf,
+    ) {
+        this.responses[pack(archive, group)] = buffer
         synchronized(lock) {
             lock.notifyAll()
         }
     }
 
-    private fun write(buffer: JagByteBuf): ChannelFuture {
+    private fun writeAndFlush(buffer: JagByteBuf): ChannelFuture {
         return this.channel.writeAndFlush(buffer.buffer)
+    }
+
+    private fun write(buffer: JagByteBuf): ChannelFuture {
+        return this.channel.write(buffer.buffer)
+    }
+
+    private fun flush() {
+        this.channel.flush()
     }
 
     public fun get(
@@ -111,20 +124,51 @@ public class Js5GroupDownloader internal constructor(
         urgent: Boolean = true,
     ): ByteBuf {
         invalidateConnection()
-        this.response = null
+        this.responses.clear()
         val buffer = Unpooled.buffer(4).toJagByteBuf()
         buffer.p1(if (urgent) 1 else 0)
         buffer.p1(archive)
         buffer.p2(group)
-        write(buffer)
+        writeAndFlush(buffer)
         await()
         // Return the response, while also skipping the archive id & group id header
-        return checkNotNull(this.response)
+        return this.responses.getValue(pack(archive, group))
+    }
+
+    public fun getBulk(requests: List<CacheGroupRequest>): Map<CacheGroupRequest, ByteBuf> {
+        invalidateConnection()
+        this.responses.clear()
+        for (request in requests) {
+            val buffer = Unpooled.buffer(4).toJagByteBuf()
+            buffer.p1(if (request.urgent) 1 else 0)
+            buffer.p1(request.archive)
+            buffer.p2(request.group)
+            write(buffer)
+        }
+        flush()
+        awaitBulk(requests.size)
+        // Return the responses, while also skipping the archive id & group id header
+        return requests.associateWith { this.responses.getValue(pack(it.archive, it.group)) }
+    }
+
+    private fun pack(
+        archive: Int,
+        group: Int,
+    ): Int {
+        return archive or (group shl 8)
     }
 
     private fun await() {
         synchronized(lock) {
             lock.wait(25_000)
+        }
+    }
+
+    private fun awaitBulk(count: Int) {
+        while (this.responses.size < count) {
+            synchronized(lock) {
+                lock.wait(25_000)
+            }
         }
     }
 

--- a/cache/src/main/kotlin/net/rsprox/cache/resolver/CacheResolver.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/resolver/CacheResolver.kt
@@ -2,6 +2,7 @@ package net.rsprox.cache.resolver
 
 import io.netty.buffer.ByteBuf
 import net.rsprox.cache.Js5MasterIndex
+import net.rsprox.cache.util.CacheGroupRequest
 
 public interface CacheResolver {
     public fun get(
@@ -9,4 +10,9 @@ public interface CacheResolver {
         archive: Int,
         group: Int,
     ): ByteBuf?
+
+    public fun getBulk(
+        masterIndex: Js5MasterIndex,
+        requests: List<CacheGroupRequest>,
+    ): Map<CacheGroupRequest, ByteBuf>
 }

--- a/cache/src/main/kotlin/net/rsprox/cache/resolver/HistoricCacheResolver.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/resolver/HistoricCacheResolver.kt
@@ -11,6 +11,9 @@ import net.rsprox.cache.identifier.DiskCacheIdentifier
 import net.rsprox.cache.identifier.OpenRs2CacheIdentifier
 import net.rsprox.cache.store.DiskGroupStore
 import net.rsprox.cache.store.OpenRs2GroupStore
+import net.rsprox.cache.util.CacheGroupRequest
+import java.util.concurrent.Callable
+import java.util.concurrent.ForkJoinPool
 
 public class HistoricCacheResolver : CacheResolver {
     private val diskCacheDictionary: DiskCacheDictionary =
@@ -72,6 +75,35 @@ public class HistoricCacheResolver : CacheResolver {
         return null
     }
 
+    override fun getBulk(
+        masterIndex: Js5MasterIndex,
+        requests: List<CacheGroupRequest>,
+    ): Map<CacheGroupRequest, ByteBuf> {
+        return buildMap {
+            val remainingRequests = requests.toMutableList()
+            // First, run a pass over local ones; these will load quick so there's no point in multithreading
+            val localIterator = remainingRequests.iterator()
+            while (localIterator.hasNext()) {
+                val request = localIterator.next()
+                val local = resolveLocal(masterIndex, request.archive, request.group)
+                if (local != null) {
+                    put(request, local)
+                    localIterator.remove()
+                }
+            }
+
+            if (remainingRequests.isNotEmpty()) {
+                val openrs2Bulk = resolveOpenRs2Bulk(masterIndex, requests)
+                remainingRequests.removeAll(openrs2Bulk.keys)
+                putAll(openrs2Bulk)
+            }
+
+            if (remainingRequests.isNotEmpty()) {
+                logger.warn { "Unable to resolve all groups in bulk request; missing groups: $requests" }
+            }
+        }
+    }
+
     private fun resolveLocal(
         masterIndex: Js5MasterIndex,
         archive: Int,
@@ -109,6 +141,37 @@ public class HistoricCacheResolver : CacheResolver {
             }
             null
         }
+    }
+
+    private fun resolveOpenRs2Bulk(
+        masterIndex: Js5MasterIndex,
+        requests: List<CacheGroupRequest>,
+    ): Map<CacheGroupRequest, ByteBuf> {
+        val jobs = mutableListOf<Callable<Pair<CacheGroupRequest, Pair<Int, ByteBuf>?>>>()
+        for (request in requests) {
+            jobs +=
+                Callable {
+                    request to resolveOpenRs2(masterIndex, request.archive, request.group)
+                }
+        }
+        logger.debug { "Searching for OpenRS2 variant of requests: $requests" }
+        val successfulResponses = mutableMapOf<CacheGroupRequest, ByteBuf>()
+        val results = ForkJoinPool.commonPool().invokeAll(jobs)
+        for (futures in results) {
+            val (request, response) = futures.get() ?: continue
+            if (response == null) continue
+            val (id, buffer) = response
+            val directory = diskCacheDictionary.getOrPut(masterIndex, id)
+            val copy = buffer.copy()
+            try {
+                DiskGroupStore(directory).put(request.archive, request.group, copy)
+            } finally {
+                copy.release()
+            }
+            logger.debug { "OpenRS2 variant found for ${request.archive}:${request.group}" }
+            successfulResponses[request] = buffer
+        }
+        return successfulResponses
     }
 
     private companion object {

--- a/cache/src/main/kotlin/net/rsprox/cache/resolver/LiveCacheResolver.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/resolver/LiveCacheResolver.kt
@@ -15,6 +15,9 @@ import net.rsprox.cache.live.Js5GroupDownloader
 import net.rsprox.cache.live.LiveConnectionInfo
 import net.rsprox.cache.store.DiskGroupStore
 import net.rsprox.cache.store.OpenRs2GroupStore
+import net.rsprox.cache.util.CacheGroupRequest
+import java.util.concurrent.Callable
+import java.util.concurrent.ForkJoinPool
 
 public class LiveCacheResolver(
     private val connectionInfo: LiveConnectionInfo,
@@ -47,6 +50,41 @@ public class LiveCacheResolver(
         if (openrs2 != null) return openrs2
         logger.warn { "Unable to obtain $archive:$group for ${masterIndex.shortHash()}" }
         return null
+    }
+
+    override fun getBulk(
+        masterIndex: Js5MasterIndex,
+        requests: List<CacheGroupRequest>,
+    ): Map<CacheGroupRequest, ByteBuf> {
+        return buildMap {
+            val remainingRequests = requests.toMutableList()
+            // First, run a pass over local ones; these will load quick so there's no point in multithreading
+            val localIterator = remainingRequests.iterator()
+            while (localIterator.hasNext()) {
+                val request = localIterator.next()
+                val local = getLocal(masterIndex, request.archive, request.group)
+                if (local != null) {
+                    put(request, local)
+                    localIterator.remove()
+                }
+            }
+
+            if (remainingRequests.isNotEmpty()) {
+                val liveBulk = getLiveBulk(masterIndex, requests)
+                remainingRequests.removeAll(liveBulk.keys)
+                putAll(liveBulk)
+            }
+
+            if (remainingRequests.isNotEmpty()) {
+                val openrs2Bulk = getOpenRs2Bulk(masterIndex, requests)
+                remainingRequests.removeAll(openrs2Bulk.keys)
+                putAll(openrs2Bulk)
+            }
+
+            if (remainingRequests.isNotEmpty()) {
+                logger.warn { "Unable to resolve all groups in bulk request; missing groups: $requests" }
+            }
+        }
     }
 
     private fun getLocal(
@@ -107,6 +145,41 @@ public class LiveCacheResolver(
         return result
     }
 
+    private fun getLiveBulk(
+        masterIndex: Js5MasterIndex,
+        requests: List<CacheGroupRequest>,
+    ): Map<CacheGroupRequest, ByteBuf> {
+        if (!this.downloader.isUpToDate(masterIndex)) {
+            logger.debug {
+                "Downloader master index out of date, establishing a new connection"
+            }
+            this.downloader.close()
+            this.downloader =
+                Js5GroupDownloader(
+                    this.js5BootstrapFactory,
+                    this.connectionInfo.copy(masterIndex = masterIndex),
+                )
+        }
+        val result =
+            try {
+                this.downloader.getBulk(requests)
+            } catch (e: Exception) {
+                logger.debug { "Unable to retrieve requests from live server: $requests" }
+                return emptyMap()
+            }
+        for ((request, buf) in result) {
+            val directory = diskCacheDictionary.getOrPut(masterIndex, null)
+            diskCacheDictionary.write()
+            val copy = buf.copy()
+            try {
+                DiskGroupStore(directory).put(request.archive, request.group, copy)
+            } finally {
+                copy.release()
+            }
+        }
+        return result
+    }
+
     private fun getOpenRs2(
         masterIndex: Js5MasterIndex,
         archive: Int,
@@ -135,6 +208,37 @@ public class LiveCacheResolver(
             "OpenRS2 variant of $archive:$group not found."
         }
         return null
+    }
+
+    private fun getOpenRs2Bulk(
+        masterIndex: Js5MasterIndex,
+        requests: List<CacheGroupRequest>,
+    ): Map<CacheGroupRequest, ByteBuf> {
+        val jobs = mutableListOf<Callable<Pair<CacheGroupRequest, Pair<Int, ByteBuf>?>>>()
+        for (request in requests) {
+            jobs +=
+                Callable {
+                    request to resolveOpenRs2(masterIndex, request.archive, request.group)
+                }
+        }
+        logger.debug { "Searching for OpenRS2 variant of requests: $requests" }
+        val successfulResponses = mutableMapOf<CacheGroupRequest, ByteBuf>()
+        val results = ForkJoinPool.commonPool().invokeAll(jobs)
+        for (futures in results) {
+            val (request, response) = futures.get() ?: continue
+            if (response == null) continue
+            val (id, buffer) = response
+            val directory = diskCacheDictionary.getOrPut(masterIndex, id)
+            val copy = buffer.copy()
+            try {
+                DiskGroupStore(directory).put(request.archive, request.group, copy)
+            } finally {
+                copy.release()
+            }
+            logger.debug { "OpenRS2 variant found for ${request.archive}:${request.group}" }
+            successfulResponses[request] = buffer
+        }
+        return successfulResponses
     }
 
     private fun resolveLocal(

--- a/cache/src/main/kotlin/net/rsprox/cache/type/OldSchoolGameValType.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/type/OldSchoolGameValType.kt
@@ -1,0 +1,84 @@
+package net.rsprox.cache.type
+
+import net.rsprot.buffer.JagByteBuf
+import net.rsprox.cache.api.type.GameVal
+import net.rsprox.cache.api.type.GameValType
+import java.nio.charset.StandardCharsets
+
+public class OldSchoolGameValType(
+    override val gameVal: GameVal,
+    override val id: Int,
+) : GameValType {
+    private val childDictionary: MutableMap<Int, String> = mutableMapOf()
+    private var value: String? = null
+
+    override fun getParentOrNull(): String? {
+        return value
+    }
+
+    override fun getChildOrNull(childId: Int): String? {
+        return childDictionary[childId and 0xFFFF]
+    }
+
+    public fun decode(
+        @Suppress("UNUSED_PARAMETER") revision: Int,
+        buffer: JagByteBuf,
+    ) {
+        when (gameVal) {
+            GameVal.IF_TYPE -> {
+                this.value = buffer.gjstr()
+
+                var componentId = 0
+                while (true) {
+                    val check = buffer.g1()
+                    if (check == 0xFF) {
+                        buffer.buffer.markReaderIndex()
+                        if (buffer.g2() == 0) {
+                            break
+                        }
+                        buffer.buffer.resetReaderIndex()
+                    }
+
+                    val componentName = buffer.gjstr()
+                    childDictionary[componentId++] = componentName
+                }
+            }
+            GameVal.TABLE_TYPE -> {
+                buffer.g1()
+                this.value = buffer.gjstr()
+
+                var columnId = 0
+                while (true) {
+                    val check = buffer.g1()
+                    if (check == 0) {
+                        break
+                    }
+
+                    val columnName = buffer.gjstr()
+                    childDictionary[columnId++] = columnName
+                }
+            }
+            else -> {
+                val array = ByteArray(buffer.readableBytes())
+                buffer.buffer.readBytes(array)
+                value = String(array, StandardCharsets.UTF_8)
+            }
+        }
+    }
+
+    public companion object {
+        public fun get(
+            revision: Int,
+            gameVal: GameVal,
+            id: Int,
+            buffer: JagByteBuf,
+        ): OldSchoolGameValType {
+            if (revision < 230) {
+                throw IllegalStateException("Revisions below 230 don't support game vals: $revision")
+            }
+            val type = OldSchoolGameValType(gameVal, id)
+            type.decode(revision, buffer)
+            return type
+        }
+    }
+}

--- a/cache/src/main/kotlin/net/rsprox/cache/util/CacheGroupRequest.kt
+++ b/cache/src/main/kotlin/net/rsprox/cache/util/CacheGroupRequest.kt
@@ -1,0 +1,7 @@
+package net.rsprox.cache.util
+
+public data class CacheGroupRequest(
+    public val archive: Int,
+    public val group: Int,
+    public val urgent: Boolean = true,
+)

--- a/gui/proxy-tool/build.gradle.kts
+++ b/gui/proxy-tool/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     implementation(rootProject.libs.netty.transport)
     implementation(rootProject.libs.netty.handler)
     implementation(rootProject.libs.netty.codec.http)
+    implementation(projects.cache)
+    implementation(projects.cache.cacheApi)
 }
 
 tasks.processResources {

--- a/gui/proxy-tool/src/main/kotlin/net/rsprox/gui/sessions/SessionPanel.kt
+++ b/gui/proxy-tool/src/main/kotlin/net/rsprox/gui/sessions/SessionPanel.kt
@@ -6,6 +6,7 @@ import com.formdev.flatlaf.extras.components.FlatScrollPane
 import com.formdev.flatlaf.extras.components.FlatToolBar
 import com.formdev.flatlaf.util.ColorFunctions
 import com.github.michaelbull.logging.InlineLogger
+import net.rsprox.cache.api.CacheProvider
 import net.rsprox.gui.App
 import net.rsprox.gui.AppIcons
 import net.rsprox.gui.dialogs.ErrorDialog
@@ -234,13 +235,18 @@ public class SessionPanel(
 
     private inner class UiSessionMonitor : SessionMonitor<BinaryHeader> {
         private var lastCycle = -1
+        private var lastCacheProvider: CacheProvider? = null
         private val formatter =
             OmitFilteredPropertyTreeFormatter(
                 PropertyFormatterCollection.default(
                     SymbolDictionaryProvider.get(),
                     App.service.settingsStore,
-                ),
+                ) { this.lastCacheProvider?.get() ?: error("Cache unavailable") },
             )
+
+        override fun onCacheUpdate(cacheProvider: CacheProvider) {
+            this.lastCacheProvider = cacheProvider
+        }
 
         override fun onLogin(header: BinaryHeader) {
             // Update the session metrics data.

--- a/proxy/src/main/kotlin/net/rsprox/proxy/binary/BinaryBlob.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/binary/BinaryBlob.kt
@@ -258,10 +258,12 @@ public data class BinaryBlob(
                     key,
                     masterIndex,
                 )
+            val cache = OldSchoolCache(LiveCacheResolver(info), masterIndex)
             val provider =
                 CacheProvider {
-                    OldSchoolCache(LiveCacheResolver(info), masterIndex)
+                    cache
                 }
+            monitor.onCacheUpdate(provider)
             decoderLoader.load(provider, header.revision)
             val latestPlugin = decoderLoader.getDecoderOrNull(header.revision)
             if (latestPlugin == null) {
@@ -295,6 +297,7 @@ public data class BinaryBlob(
                     decodingSession,
                     runner,
                     sessionTracker,
+                    provider,
                 )
             this.liveSession = liveSession
             liveSession.setRevision(header.revision)

--- a/proxy/src/main/kotlin/net/rsprox/proxy/util/NopSessionMonitor.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/util/NopSessionMonitor.kt
@@ -1,5 +1,6 @@
 package net.rsprox.proxy.util
 
+import net.rsprox.cache.api.CacheProvider
 import net.rsprox.proxy.binary.BinaryHeader
 import net.rsprox.shared.SessionMonitor
 import net.rsprox.shared.property.RootProperty
@@ -9,6 +10,9 @@ public object NopSessionMonitor : SessionMonitor<BinaryHeader> {
     }
 
     override fun onLogout(header: BinaryHeader) {
+    }
+
+    override fun onCacheUpdate(cacheProvider: CacheProvider) {
     }
 
     override fun onIncomingBytesPerSecondUpdate(bytesPerLastSecond: Long) {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -4,4 +4,6 @@ dependencies {
     implementation(libs.rsprot.buffer)
     implementation(projects.protocol)
     implementation(libs.inline.logger)
+    implementation(projects.cache)
+    implementation(projects.cache.cacheApi)
 }

--- a/shared/src/main/kotlin/net/rsprox/shared/SessionMonitor.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/SessionMonitor.kt
@@ -1,11 +1,14 @@
 package net.rsprox.shared
 
+import net.rsprox.cache.api.CacheProvider
 import net.rsprox.shared.property.RootProperty
 
 public interface SessionMonitor<T> {
     public fun onLogin(header: T)
 
     public fun onLogout(header: T)
+
+    public fun onCacheUpdate(cacheProvider: CacheProvider)
 
     public fun onIncomingBytesPerSecondUpdate(bytesPerLastSecond: Long)
 

--- a/shared/src/main/kotlin/net/rsprox/shared/property/PropertyFormatterCollection.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/PropertyFormatterCollection.kt
@@ -1,5 +1,6 @@
 package net.rsprox.shared.property
 
+import net.rsprox.cache.api.CacheProvider
 import net.rsprox.shared.BaseVarType
 import net.rsprox.shared.ScriptVarType
 import net.rsprox.shared.property.filtered.FilteredNamedEnumProperty
@@ -20,6 +21,7 @@ import net.rsprox.shared.property.regular.VarpProperty
 import net.rsprox.shared.property.regular.ZoneCoordProperty
 import net.rsprox.shared.settings.Setting
 import net.rsprox.shared.settings.SettingSetStore
+import net.rsprox.shared.symbols.CacheSymbolDictionary
 
 public class PropertyFormatterCollection private constructor(
     private val formatters: Map<Class<*>, PropertyFormatter<*>>,
@@ -60,12 +62,16 @@ public class PropertyFormatterCollection private constructor(
         public fun default(
             systemDictionary: SymbolDictionary,
             settingStore: SettingSetStore,
+            cacheProvider: CacheProvider,
         ): PropertyFormatterCollection {
             val settings = settingStore.getActive()
+            val cacheSymbolDictionary = CacheSymbolDictionary(cacheProvider)
 
             fun dictionary(): SymbolDictionary =
                 if (settings[Setting.DISABLE_DICTIONARY_NAMES]) {
                     NopSymbolDictionary
+                } else if (settings[Setting.USE_OFFICIAL_DICTIONARY]) {
+                    cacheSymbolDictionary.also { it.start() }
                 } else {
                     systemDictionary
                 }

--- a/shared/src/main/kotlin/net/rsprox/shared/settings/Setting.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/settings/Setting.kt
@@ -64,6 +64,13 @@ public enum class Setting(
         false,
         "Temporarily disable provided dictionary names for types. Dictionaries allow you to map number ids to text.",
     ),
+    USE_OFFICIAL_DICTIONARY(
+        SettingGroup.LOGGING,
+        SettingCategory.MISC,
+        "Use Official Dictionary",
+        true,
+        "Enables official gameval dictionary loaded from the cache. This will override custom user dictionary.",
+    ),
     PLAYER_EXT_INFO_INLINE(
         SettingGroup.LOGGING,
         SettingCategory.PLAYER_INFO,

--- a/shared/src/main/kotlin/net/rsprox/shared/symbols/CacheSymbolDictionary.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/symbols/CacheSymbolDictionary.kt
@@ -1,0 +1,83 @@
+package net.rsprox.shared.symbols
+
+import net.rsprox.cache.api.Cache
+import net.rsprox.cache.api.CacheProvider
+import net.rsprox.cache.api.type.GameVal
+import net.rsprox.cache.api.type.GameValType
+import net.rsprox.shared.ScriptVarType
+import net.rsprox.shared.property.SymbolDictionary
+
+public class CacheSymbolDictionary(
+    private val cacheProvider: CacheProvider,
+) : SymbolDictionary {
+    private var lastLoadedCache: Cache? = null
+    private var gameValTypes: Map<GameVal, Map<Int, GameValType>>? = null
+
+    override fun getScriptVarTypeName(
+        id: Int,
+        type: ScriptVarType,
+    ): String? {
+        return when (type) {
+            ScriptVarType.INTERFACE -> {
+                gameValTypes?.get(GameVal.IF_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.INV -> {
+                gameValTypes?.get(GameVal.INV_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.LOC -> {
+                gameValTypes?.get(GameVal.LOC_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.NPC -> {
+                gameValTypes?.get(GameVal.NPC_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.OBJ -> {
+                gameValTypes?.get(GameVal.OBJ_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.DBROW -> {
+                gameValTypes?.get(GameVal.ROW_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.SEQ -> {
+                gameValTypes?.get(GameVal.SEQ_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.SPOTANIM -> {
+                gameValTypes?.get(GameVal.SPOT_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.DBTABLE -> {
+                gameValTypes?.get(GameVal.SPOT_TYPE)?.get(id)?.getParentOrNull()
+            }
+            ScriptVarType.COMPONENT -> {
+                val interfaceType = gameValTypes?.get(GameVal.IF_TYPE)?.get(id ushr 16) ?: return null
+                val interfaceName = interfaceType.getParentOrNull() ?: return null
+                val componentName = interfaceType.getChildOrNull(id and 0xFFFF) ?: return null
+                "$interfaceName:$componentName"
+            }
+            else -> null
+        }
+    }
+
+    override fun getVarpName(id: Int): String? {
+        return gameValTypes?.get(GameVal.VARP_TYPE)?.get(id)?.getParentOrNull()
+    }
+
+    override fun getVarbitName(id: Int): String? {
+        return gameValTypes?.get(GameVal.VARBIT_TYPE)?.get(id)?.getParentOrNull()
+    }
+
+    override fun getScriptName(id: Int): String? {
+        return null
+    }
+
+    @Synchronized
+    override fun start() {
+        val currentCache = cacheProvider.get()
+        if (currentCache != lastLoadedCache) {
+            this.lastLoadedCache = currentCache
+            this.gameValTypes = currentCache.allGameValTypes()
+        }
+    }
+
+    override fun stop() {
+        this.lastLoadedCache = null
+        this.gameValTypes = null
+    }
+}

--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextTranscriberProvider.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextTranscriberProvider.kt
@@ -29,6 +29,7 @@ public class TextTranscriberProvider : TranscriberProvider {
                 PropertyFormatterCollection.default(
                     dictionary,
                     settings,
+                    cacheProvider,
                 ),
             )
         val monitoredContainer = MonitoredMessageConsumerContainer(container, monitor)


### PR DESCRIPTION
Adds support for loading gamevals from the cache, providing official jagex names for those that opt into it.
It should be noted that this requires downloading a decent amount of files which is done before any transcribing can occur, and may cause slowdowns on initial transcriptions.

An example of what this introduces:
![image](https://github.com/user-attachments/assets/6ede2002-b44f-49a5-9462-66d562ecf7cc)


Note: This can be opted out of by disabling official dictionary in RSProx settings. The ids-after-symbols  can be opted out of as well.