### PR TITLE
Adds support for angle in initial npc spawn detection

### DIFF
--- a/shared/src/main/kotlin/net/rsprox/shared/property/PropertyExtensions.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/PropertyExtensions.kt
@@ -434,6 +434,7 @@ public fun Property.identifiedNpc(
     level: Int,
     x: Int,
     z: Int,
+    angle: Int,
     propertyName: String = "npc",
 ): IdentifiedNpcProperty {
     return child(
@@ -445,6 +446,7 @@ public fun Property.identifiedNpc(
             level,
             x,
             z,
+            angle
         ),
     )
 }
@@ -457,6 +459,7 @@ public fun Property.identifiedMultinpc(
     level: Int,
     x: Int,
     z: Int,
+    angle: Int,
     propertyName: String = "npc",
 ): IdentifiedMultinpcProperty {
     return child(
@@ -469,6 +472,7 @@ public fun Property.identifiedMultinpc(
             level,
             x,
             z,
+            angle
         ),
     )
 }

--- a/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedMultinpcProperty.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedMultinpcProperty.kt
@@ -15,6 +15,7 @@ public class IdentifiedMultinpcProperty(
     level: Int,
     x: Int,
     z: Int,
+    public val angle: Int,
 ) : IdentifiedChildProperty(propertyName, index, level, x, z) {
     override fun formattedValue(
         settings: SettingSet,
@@ -59,6 +60,8 @@ public class IdentifiedMultinpcProperty(
             } else {
                 append("coord=($x, $z, $level)")
             }
+
+            append(", angle=$angle")
 
             append(')')
         }

--- a/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedNpcProperty.kt
+++ b/shared/src/main/kotlin/net/rsprox/shared/property/regular/IdentifiedNpcProperty.kt
@@ -14,6 +14,7 @@ public class IdentifiedNpcProperty(
     level: Int,
     x: Int,
     z: Int,
+    public val angle: Int,
 ) : IdentifiedChildProperty(propertyName, index, level, x, z) {
     override fun formattedValue(
         settings: SettingSet,
@@ -46,6 +47,8 @@ public class IdentifiedNpcProperty(
             } else {
                 append("coord=($x, $z, $level)")
             }
+
+            append(", angle=$angle")
 
             append(')')
         }

--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/state/Npc.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/state/Npc.kt
@@ -6,6 +6,7 @@ public data class Npc(
     public val index: Int,
     public val id: Int,
     public val creationCycle: Int,
+    public val angle: Int,
     public val coord: CoordGrid,
     public val name: String? = null,
 )

--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/state/SessionTracker.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/state/SessionTracker.kt
@@ -267,6 +267,7 @@ public class SessionTracker(
                                 update.id,
                                 name,
                                 update.spawnCycle,
+                                update.angle,
                                 CoordGrid(update.level, update.x, update.z),
                             )
                         }

--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/state/World.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/state/World.kt
@@ -129,9 +129,10 @@ public class World(
         id: Int,
         name: String?,
         creationCycle: Int,
+        angle: Int,
         coordGrid: CoordGrid,
     ): Npc {
-        val new = Npc(index, id, creationCycle, coordGrid, name)
+        val new = Npc(index, id, creationCycle, angle, coordGrid, name)
         val old = this.npcs.put(index, new)
         check(old == null) {
             "Overriding npc $index"
@@ -144,7 +145,7 @@ public class World(
         coordGrid: CoordGrid,
     ) {
         val old = getNpc(index)
-        this.npcs[index] = Npc(old.index, old.id, old.creationCycle, coordGrid, old.name)
+        this.npcs[index] = Npc(old.index, old.id, old.creationCycle, old.angle, coordGrid, old.name)
     }
 
     public fun updateNpcName(
@@ -153,7 +154,7 @@ public class World(
         newName: String?,
     ) {
         val old = getNpc(index)
-        this.npcs[index] = Npc(old.index, newId, old.creationCycle, old.coord, newName)
+        this.npcs[index] = Npc(old.index, newId, old.creationCycle, old.angle, old.coord, newName)
     }
 
     public fun removeNpc(index: Int) {

--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextClientPacketTranscriber.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextClientPacketTranscriber.kt
@@ -138,6 +138,7 @@ public open class TextClientPacketTranscriber(
             }
         val multinpc = sessionState.resolveMultinpc(npc.id, cache)
         val coord = sessionState.getActiveWorld().getInstancedCoordOrSelf(npc.coord)
+        val angle = npc.angle
         return if (multinpc != null) {
             identifiedMultinpc(
                 finalIndex,
@@ -147,6 +148,7 @@ public open class TextClientPacketTranscriber(
                 coord.level,
                 coord.x,
                 coord.z,
+                angle
             )
         } else {
             identifiedNpc(
@@ -156,6 +158,7 @@ public open class TextClientPacketTranscriber(
                 coord.level,
                 coord.x,
                 coord.z,
+                angle
             )
         }
     }

--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextNpcInfoTranscriber.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextNpcInfoTranscriber.kt
@@ -109,6 +109,7 @@ public class TextNpcInfoTranscriber(
             }
         val multinpc = sessionState.resolveMultinpc(npc.id, cache)
         val coord = sessionState.getActiveWorld().getInstancedCoordOrSelf(npc.coord)
+        val angle = npc.angle
         return if (multinpc != null) {
             identifiedMultinpc(
                 finalIndex,
@@ -118,6 +119,7 @@ public class TextNpcInfoTranscriber(
                 coord.level,
                 coord.x,
                 coord.z,
+                angle
             )
         } else {
             identifiedNpc(
@@ -127,6 +129,7 @@ public class TextNpcInfoTranscriber(
                 coord.level,
                 coord.x,
                 coord.z,
+                angle
             )
         }
     }

--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextPlayerInfoTranscriber.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextPlayerInfoTranscriber.kt
@@ -91,6 +91,7 @@ public class TextPlayerInfoTranscriber(
             }
         val multinpc = sessionState.resolveMultinpc(npc.id, cache)
         val coord = sessionState.getActiveWorld().getInstancedCoordOrSelf(npc.coord)
+        val angle = npc.angle
         return if (multinpc != null) {
             identifiedMultinpc(
                 finalIndex,
@@ -100,6 +101,7 @@ public class TextPlayerInfoTranscriber(
                 coord.level,
                 coord.x,
                 coord.z,
+                angle
             )
         } else {
             identifiedNpc(
@@ -109,6 +111,7 @@ public class TextPlayerInfoTranscriber(
                 coord.level,
                 coord.x,
                 coord.z,
+                angle
             )
         }
     }

--- a/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextServerPacketTranscriber.kt
+++ b/transcriber/src/main/kotlin/net/rsprox/transcriber/text/TextServerPacketTranscriber.kt
@@ -171,6 +171,7 @@ public class TextServerPacketTranscriber(
             }
         val multinpc = sessionState.resolveMultinpc(npc.id, cache)
         val coord = sessionState.getActiveWorld().getInstancedCoordOrSelf(npc.coord)
+        val angle = npc.angle
         return if (multinpc != null) {
             identifiedMultinpc(
                 finalIndex,
@@ -180,6 +181,7 @@ public class TextServerPacketTranscriber(
                 coord.level,
                 coord.x,
                 coord.z,
+                angle
             )
         } else {
             identifiedNpc(
@@ -189,6 +191,7 @@ public class TextServerPacketTranscriber(
                 coord.level,
                 coord.x,
                 coord.z,
+                angle
             )
         }
     }


### PR DESCRIPTION
Adds support for NPC orientation by capturing and propagating the angle field in the Npc model, session tracker, and transcription layer so spawn transcription now includes the initial facing direction.