### PR TITLE
feat: allow users to run native client under proton

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ On Linux, there are a few extra steps involved in setting up a Jagex Account:
 4. You must then make yourself the owner of the file, this is done via `sudo chown "$USER" ~/.rsprox/jagex-accounts.properties`.
 5. You can now simply run `RSProx.AppImage` and you will be able to access your Jagex Account.
 
+Additionally, if you would like to run the Native Client under Proton (at the time of writing this is currently necessary to use the new renderer), you must create a `protonpath` file in `~/.rsprox/` containing the file path to a proton executable, for example:
+```
+/home/grian/.steam/steam/steamapps/common/Proton - Experimental/proton
+```
+
 ### Security
 We have taken many measures to ensure the players can securely use this tool,
 without having to worry about getting banned or having their information leaked.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Below is a small task list showing a rough breakdown of what the tool will consi
 
 - [ ] Patch Tool
   - [x] Native (Win)
-    - [x] Supports Unix via `wine`
+    - [x] Supports Unix via `wine` or `proton`
   - [ ] ~~Native (Mac)~~ (Automated patching too fragile)
   - [x] RuneLite (All Operating systems)
 - [x] World identification via localhost address

--- a/proxy/src/main/kotlin/net/rsprox/proxy/ProxyService.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/ProxyService.kt
@@ -718,15 +718,32 @@ public class ProxyService(
                 try {
                     val directory = path.parent.toFile()
                     val absolutePath = path.absolutePathString()
-                    createProcess(
-                        listOf("wine", absolutePath),
-                        directory,
-                        path,
-                        port,
-                        character,
-                        operatingSystem,
-                        ClientType.Native,
-                    )
+
+                    val protonFilePath  = CONFIGURATION_PATH.absolutePathString() + "/protonpath"
+                    val protonFile = Path(protonFilePath)
+
+                    if (protonFile.exists()) {
+                        createProcess(
+                            listOf(protonFile.readText().trim(), "run", absolutePath),
+                            directory,
+                            path,
+                            port,
+                            character,
+                            operatingSystem,
+                            ClientType.Native,
+                            true
+                        )
+                    } else {
+                        createProcess(
+                            listOf("wine", absolutePath),
+                            directory,
+                            path,
+                            port,
+                            character,
+                            operatingSystem,
+                            ClientType.Native,
+                        )
+                    }
                 } catch (e: IOException) {
                     throw RuntimeException("wine is required to run the enhanced client on unix", e)
                 }
@@ -744,6 +761,7 @@ public class ProxyService(
         character: JagexCharacter?,
         operatingSystem: OperatingSystem,
         clientType: ClientType,
+        proton: Boolean = false,
     ) {
         logger.debug { "Attempting to create process $command" }
         val builder =
@@ -761,6 +779,14 @@ public class ProxyService(
                 builder.environment()["JX_REFRESH_TOKEN"] = ""
                 builder.environment()["JX_DISPLAY_NAME"] = character.displayName ?: ""
                 builder.environment()["JX_ACCESS_TOKEN"] = ""
+                if (proton) {
+                    val pfxFolder = CONFIGURATION_PATH.absolutePathString() + "/proton_pfx"
+                    val pfxPath = Path(pfxFolder)
+                    if (pfxPath.notExists()) pfxPath.createDirectory()
+                    // half sure steam doesnt even work properly if in any other loc so kind of safe to hardcode
+                    builder.environment()["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = "~/.steam/steam"
+                    builder.environment()["STEAM_COMPAT_DATA_PATH"] = pfxFolder
+                }
             }
         } else {
             builder.environment().putAll(

--- a/proxy/src/main/kotlin/net/rsprox/proxy/ProxyService.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/ProxyService.kt
@@ -771,6 +771,14 @@ public class ProxyService(
         if (directory != null) {
             builder.directory(directory)
         }
+        if (proton) {
+            val pfxFolder = CONFIGURATION_PATH.absolutePathString() + "/proton_pfx"
+            val pfxPath = Path(pfxFolder)
+            if (pfxPath.notExists()) pfxPath.createDirectory()
+            // half sure steam doesn't even work properly if in any other loc so kind of safe to hardcode
+            builder.environment()["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = System.getProperty("user.home ") + "/.steam/steam"
+            builder.environment()["STEAM_COMPAT_DATA_PATH"] = pfxFolder
+        }
         if (character != null) {
             val account = jagexAccountStore.accounts.firstOrNull { it.characters.contains(character) }
             if (account != null) {
@@ -779,14 +787,6 @@ public class ProxyService(
                 builder.environment()["JX_REFRESH_TOKEN"] = ""
                 builder.environment()["JX_DISPLAY_NAME"] = character.displayName ?: ""
                 builder.environment()["JX_ACCESS_TOKEN"] = ""
-                if (proton) {
-                    val pfxFolder = CONFIGURATION_PATH.absolutePathString() + "/proton_pfx"
-                    val pfxPath = Path(pfxFolder)
-                    if (pfxPath.notExists()) pfxPath.createDirectory()
-                    // half sure steam doesn't even work properly if in any other loc so kind of safe to hardcode
-                    builder.environment()["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = System.getProperty("user.home ") + "/.steam/steam"
-                    builder.environment()["STEAM_COMPAT_DATA_PATH"] = pfxFolder
-                }
             }
         } else {
             builder.environment().putAll(

--- a/proxy/src/main/kotlin/net/rsprox/proxy/ProxyService.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/ProxyService.kt
@@ -783,8 +783,8 @@ public class ProxyService(
                     val pfxFolder = CONFIGURATION_PATH.absolutePathString() + "/proton_pfx"
                     val pfxPath = Path(pfxFolder)
                     if (pfxPath.notExists()) pfxPath.createDirectory()
-                    // half sure steam doesnt even work properly if in any other loc so kind of safe to hardcode
-                    builder.environment()["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = "~/.steam/steam"
+                    // half sure steam doesn't even work properly if in any other loc so kind of safe to hardcode
+                    builder.environment()["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = System.getProperty("user.home ") + "/.steam/steam"
                     builder.environment()["STEAM_COMPAT_DATA_PATH"] = pfxFolder
                 }
             }


### PR DESCRIPTION
This pr does the following:
- Adds a proton boolean argument to createProcess & sets the env variables required for proton to work if it passed true, specifically, this creates a `proton_pfx` folder if it doesn't exists, which is where the wine filesystem for rsprox will be held.
- The proton boolean arg is set to true if the `protonpath` file exists in the .rsprox config folder, this should only contain the file path to the proton executable (as it can vary due to differing proton versions)
- Adds documentation about it under linux setup in readme