### PR TITLE
Add binary log data processing

### DIFF
--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -1,0 +1,15 @@
+dependencies {
+    implementation(rootProject.libs.rsprot.protocol)
+    implementation(projects.cache)
+    implementation(projects.cache.cacheApi)
+    implementation(projects.protocol)
+    implementation(projects.proxy)
+    implementation(projects.shared)
+    findSubprojects(projects.protocol.name).forEach {
+        implementation(it)
+    }
+}
+
+fun findSubprojects(parentProject: String): List<Project> {
+    return project(":$parentProject").subprojects.filter { it.buildFile.exists() }
+}

--- a/processor/src/main/kotlin/net/rsprox/processor/BinaryProcessor.kt
+++ b/processor/src/main/kotlin/net/rsprox/processor/BinaryProcessor.kt
@@ -1,0 +1,86 @@
+package net.rsprox.processor
+
+import net.rsprox.cache.Js5MasterIndex
+import net.rsprox.cache.resolver.HistoricCacheResolver
+import net.rsprox.processor.filters.ProcessorPropertyFilterSetStore
+import net.rsprox.processor.result.ProcessedBinarySession
+import net.rsprox.processor.settings.ProcessorSettingSetStore
+import net.rsprox.proxy.binary.BinaryBlob
+import net.rsprox.proxy.cache.CachedCaches
+import net.rsprox.proxy.cache.StatefulCacheProvider
+import net.rsprox.proxy.huffman.HuffmanProvider
+import net.rsprox.proxy.plugin.DecoderLoader
+import net.rsprox.proxy.plugin.DecodingSession
+import net.rsprox.shared.filters.PropertyFilterSetStore
+import net.rsprox.shared.settings.SettingSetStore
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+
+public sealed class BinaryProcessor(private val files: Collection<Path>) {
+    protected fun collectAll(): List<ProcessedBinarySession> {
+        val decoderLoader = DecoderLoader()
+        HuffmanProvider.load()
+        val cacheProvider = StatefulCacheProvider(CachedCaches(HistoricCacheResolver()))
+        return collectAll(ProcessorPropertyFilterSetStore, ProcessorSettingSetStore, decoderLoader, cacheProvider)
+    }
+
+    private fun collectAll(
+        filters: PropertyFilterSetStore,
+        settings: SettingSetStore,
+        decoderLoader: DecoderLoader,
+        cacheProvider: StatefulCacheProvider
+    ): List<ProcessedBinarySession> {
+        val fileTreeWalk =
+            files.map { it to BinaryBlob.decode(it, filters, settings) }.sortedBy { it.second.header.revision }
+        return fileTreeWalk.map { (path, binary) -> process(path, binary, decoderLoader, cacheProvider) }
+    }
+
+    private fun process(
+        binaryPath: Path,
+        binary: BinaryBlob,
+        decoderLoader: DecoderLoader,
+        cacheProvider: StatefulCacheProvider,
+    ): ProcessedBinarySession {
+        cacheProvider.update(
+            Js5MasterIndex.trimmed(
+                binary.header.revision,
+                binary.header.js5MasterIndex,
+            ),
+        )
+        decoderLoader.load(cacheProvider)
+        val latestPlugin = decoderLoader.getDecoder(binary.header.revision, cacheProvider)
+        val session = DecodingSession(binary, latestPlugin)
+        val messages = session.sequence().map { it.message }.toList()
+        return ProcessedBinarySession(binaryPath, binary.header, messages)
+    }
+
+    public class SingleBinaryProcessor(file: Path) : BinaryProcessor(listOf(file)) {
+        public fun collect(): ProcessedBinarySession {
+            val sessions = collectAll()
+            return sessions.single()
+        }
+    }
+
+    public class MultiBinaryProcessor(files: Collection<Path>) : BinaryProcessor(files) {
+        public fun collect(): List<ProcessedBinarySession> {
+            return collectAll()
+        }
+    }
+
+    public companion object {
+        public fun fromFolder(path: Path): MultiBinaryProcessor {
+            require(path.isDirectory()) { "Path must be a directory: ${path.absolutePathString()}" }
+            val fileTreeWalk = path.toFile().walkTopDown().filter { it.extension == "bin" }.map { it.toPath() }
+            return MultiBinaryProcessor(fileTreeWalk.toList())
+        }
+
+        public fun fromFile(file: Path): SingleBinaryProcessor {
+            require(file.isRegularFile()) { "Binary file could not be found: ${file.absolutePathString()}" }
+            check(file.extension == "bin") { "Binary file must have a .bin extension: ${file.absolutePathString()}" }
+            return SingleBinaryProcessor(file)
+        }
+    }
+}

--- a/processor/src/main/kotlin/net/rsprox/processor/filters/ProcessorPropertyFilterSetStore.kt
+++ b/processor/src/main/kotlin/net/rsprox/processor/filters/ProcessorPropertyFilterSetStore.kt
@@ -1,0 +1,101 @@
+package net.rsprox.processor.filters
+
+import net.rsprox.shared.StreamDirection
+import net.rsprox.shared.filters.PropertyFilter
+import net.rsprox.shared.filters.PropertyFilterSet
+import net.rsprox.shared.filters.PropertyFilterSetStore
+import net.rsprox.shared.filters.ProtCategory
+import net.rsprox.shared.filters.RegexFilter
+
+public object ProcessorPropertyFilterSetStore : PropertyFilterSetStore {
+    override val size: Int
+        get() = 1
+
+    override fun create(name: String): PropertyFilterSet {
+        throw UnsupportedOperationException("Cannot mutate processor property filter set store.")
+    }
+
+    override fun delete(index: Int): PropertyFilterSet? {
+        throw UnsupportedOperationException("Cannot mutate processor property filter set store.")
+    }
+
+    override fun get(index: Int): PropertyFilterSet? {
+        if (index != 0) {
+            throw IndexOutOfBoundsException("Processor property filter only has a single property filter set.")
+        }
+        return ProcessorFilterSet
+    }
+
+    override fun getActive(): PropertyFilterSet {
+        return ProcessorFilterSet
+    }
+
+    override fun setActive(index: Int) {
+        throw UnsupportedOperationException("Cannot mutate processor property filter set store.")
+    }
+
+    private object ProcessorFilterSet : PropertyFilterSet {
+        override fun getCreationTime(): Long {
+            return System.currentTimeMillis()
+        }
+
+        override fun getName(): String {
+            return "Processor"
+        }
+
+        override fun setName(name: String) {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun deleteBackingFile() {
+            throw UnsupportedOperationException("Processor filter set does not have a backing file.")
+        }
+
+        override fun get(filter: PropertyFilter): Boolean {
+            return true
+        }
+
+        override fun set(filter: PropertyFilter, enabled: Boolean) {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun set(category: ProtCategory, enabled: Boolean) {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun set(streamDirection: StreamDirection, enabled: Boolean) {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun setAll(enabled: Boolean) {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun setDefaults() {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun getRegexFilters(): List<RegexFilter> {
+            return emptyList()
+        }
+
+        override fun addRegexFilter(regexFilter: RegexFilter) {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun removeRegexFilter(regexFilter: RegexFilter) {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun replaceRegexFilter(
+            oldRegexFilter: RegexFilter,
+            newRegexFilter: RegexFilter
+        ) {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+
+        override fun clearRegexFilters() {
+            throw UnsupportedOperationException("Cannot mutate processor property filter set.")
+        }
+    }
+}

--- a/processor/src/main/kotlin/net/rsprox/processor/result/ProcessedBinarySession.kt
+++ b/processor/src/main/kotlin/net/rsprox/processor/result/ProcessedBinarySession.kt
@@ -1,0 +1,15 @@
+package net.rsprox.processor.result
+
+import net.rsprot.protocol.message.IncomingMessage
+import net.rsprox.proxy.binary.BinaryHeader
+import java.nio.file.Path
+
+public class ProcessedBinarySession(
+    public val file: Path,
+    public val header: BinaryHeader,
+    private val messages: List<IncomingMessage>,
+) : List<IncomingMessage> by messages {
+    public fun toTickTimestamped(): TimestampedBinarySession {
+        return TimestampedBinarySession.from(this)
+    }
+}

--- a/processor/src/main/kotlin/net/rsprox/processor/result/TimestampedBinarySession.kt
+++ b/processor/src/main/kotlin/net/rsprox/processor/result/TimestampedBinarySession.kt
@@ -1,0 +1,35 @@
+package net.rsprox.processor.result
+
+import net.rsprot.protocol.message.IncomingMessage
+import net.rsprox.protocol.game.outgoing.model.misc.client.ServerTickEnd
+import net.rsprox.proxy.binary.BinaryHeader
+import java.nio.file.Path
+
+/**
+ * A server-tick-indexed representation of [ProcessedBinarySession].
+ *
+ * Each map key represents the server tick (starting at `0` and incrementing after every [ServerTickEnd] message).
+ * Each map value contains all [net.rsprot.protocol.message.IncomingMessage]s sent during said tick, excluding
+ * [ServerTickEnd] itself.
+ */
+public class TimestampedBinarySession private constructor(
+    public val file: Path,
+    public val header: BinaryHeader,
+    private val timestamped: Map<Int, List<IncomingMessage>>,
+) : Map<Int, List<IncomingMessage>> by timestamped {
+    public companion object {
+        public fun from(session: ProcessedBinarySession): TimestampedBinarySession {
+            val timestamped = mutableMapOf<Int, MutableList<IncomingMessage>>()
+            var currentTick = 0
+            for (message in session) {
+                if (message is ServerTickEnd) {
+                    currentTick++
+                    continue
+                }
+                val messages = timestamped.getOrPut(currentTick) { mutableListOf() }
+                messages += message
+            }
+            return TimestampedBinarySession(session.file, session.header, timestamped)
+        }
+    }
+}

--- a/processor/src/main/kotlin/net/rsprox/processor/settings/ProcessorSettingSetStore.kt
+++ b/processor/src/main/kotlin/net/rsprox/processor/settings/ProcessorSettingSetStore.kt
@@ -1,0 +1,77 @@
+package net.rsprox.processor.settings
+
+import net.rsprox.shared.settings.Setting
+import net.rsprox.shared.settings.SettingCategory
+import net.rsprox.shared.settings.SettingGroup
+import net.rsprox.shared.settings.SettingSet
+import net.rsprox.shared.settings.SettingSetStore
+
+public object ProcessorSettingSetStore : SettingSetStore {
+    override val size: Int
+        get() = 1
+
+    override fun create(name: String): SettingSet {
+        throw UnsupportedOperationException("Cannot mutate processor settings set store.")
+    }
+
+    override fun delete(index: Int): SettingSet? {
+        throw UnsupportedOperationException("Cannot mutate processor settings set store.")
+    }
+
+    override fun get(index: Int): SettingSet? {
+        if (index != 0) {
+            throw IndexOutOfBoundsException("Processor settings set store only has a single settings set.")
+        }
+        return PropertySettingSet
+    }
+
+    override fun getActive(): SettingSet {
+        return PropertySettingSet
+    }
+
+    override fun setActive(index: Int) {
+        throw UnsupportedOperationException("Cannot mutate processor settings set store.")
+    }
+
+    private object PropertySettingSet : SettingSet {
+        override fun getCreationTime(): Long {
+            return System.currentTimeMillis()
+        }
+
+        override fun getName(): String {
+            return "Processor"
+        }
+
+        override fun setName(name: String) {
+            throw UnsupportedOperationException("Cannot mutate processor settings set.")
+        }
+
+        override fun deleteBackingFile() {
+            throw UnsupportedOperationException("Processor settings set does not have a backing file.")
+        }
+
+        override fun get(setting: Setting): Boolean {
+            return true
+        }
+
+        override fun set(setting: Setting, enabled: Boolean) {
+            throw UnsupportedOperationException("Cannot mutate processor settings set.")
+        }
+
+        override fun set(category: SettingCategory, enabled: Boolean) {
+            throw UnsupportedOperationException("Cannot mutate processor settings set.")
+        }
+
+        override fun set(group: SettingGroup, enabled: Boolean) {
+            throw UnsupportedOperationException("Cannot mutate processor settings set.")
+        }
+
+        override fun setAll(enabled: Boolean) {
+            throw UnsupportedOperationException("Cannot mutate processor settings set.")
+        }
+
+        override fun setDefaults() {
+            throw UnsupportedOperationException("Cannot mutate processor settings set.")
+        }
+    }
+}

--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -30,19 +30,9 @@ dependencies {
     implementation(libs.junixsocket)
     implementation(libs.okhttp3)
     implementation(libs.gson)
-    implementation(projects.protocol.osrs223)
-    implementation(projects.protocol.osrs224)
-    implementation(projects.protocol.osrs225)
-    implementation(projects.protocol.osrs226)
-    implementation(projects.protocol.osrs227)
-    implementation(projects.protocol.osrs228)
-    implementation(projects.protocol.osrs229)
-    implementation(projects.protocol.osrs230)
-    implementation(projects.protocol.osrs231)
-    implementation(projects.protocol.osrs232)
-    implementation(projects.protocol.osrs233)
-    implementation(projects.protocol.osrs234)
-    implementation(projects.protocol.osrs235)
+    findSubprojects(projects.protocol.name).forEach {
+        implementation(it)
+    }
 }
 
 tasks.build.configure {
@@ -89,4 +79,8 @@ fun searchSubproject(
     val relativePath = projectPath.relativize(subprojectPath)
     val subprojectName = relativePath.toString().replace(File.separator, ":")
     return "$projectName:$subprojectName"
+}
+
+fun findSubprojects(parentProject: String): List<Project> {
+    return project(":$parentProject").subprojects.filter { it.buildFile.exists() }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(
     "proxy",
+    "processor",
     "protocol",
     "patch",
     "gui",


### PR DESCRIPTION
Adds a simple system that provides [BinaryProcessor.fromFile] and [BinaryProcessor.fromFolder] to parse 
binary logs and produce [ProcessedBinarySession]s. Each session exposes the file path, binary header, and a 
list of [IncomingGameMessage]s. Sessions can be further aggregated into a [TimestampedBinarySession], 
which maps messages by the game tick they were sent or received.

Note: RSProx transcriber maintains some internal state (e.g., tracking the player's viewport to offset local 
coordinates). This functionality can be layered on top of this system in the future if needed.