### PR TITLE
Automatic on-demand macOS loopback aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,21 +86,49 @@ filter preset.
 > your PC.
 
 #### MacOS Support
-MacOS does not whitelist any loopback address other than 127.0.0.1 by default,
-which means RSProx cannot establish a connection, as we use unique
+MacOS does not treat any loopback address other than 127.0.0.1 as local by
+default, which means RSProx cannot establish a connection, as we use unique
 loopback addresses per connection established, which describes the world to
 which we're connecting.
 
-As such, it is necessary for anyone connecting via MacOS to run some commands.
-In order to whitelist the necessary loopback addresses, this script must be run:
-(Note that for custom private server targets, the group id must be changed from
-2 to 3+, where 3 is the first custom target, 4 is the second and so on)
+RSProx now manages these loopback (`lo0`) aliases for you automatically - there
+is no longer any need to run the manual script below. Adding an alias requires
+root, so the first time one is needed RSProx shows a single macOS administrator
+prompt that starts a small helper **for that session only**. The helper just
+keeps `lo0` in sync with what RSProx asks for and removes every alias again the
+moment RSProx closes (or is killed). Nothing is installed, no `sudoers` entry is
+written, and no standing password-less root access is left behind - if you quit
+and relaunch RSProx you will be prompted once more.
 
-> [!WARNING]
-> Whitelisting a lot of worlds will result in DNS lookups significantly slowing
-> down. It is recommended you only select your preferred worlds and whitelist
-> those specific ones. Ensure that your default world is configured and
-> whitelisted, or the client will not be able to boot up.
+Because macOS scans every loopback alias on each outbound connection, keeping
+hundreds of them present at once slows down all networking (and DNS) system-wide.
+RSProx therefore aliases worlds strictly **on demand**: it watches for the client
+trying to reach the proxy (a `SYN_SENT` socket in `netstat`), aliases just that
+address, and the client's own connection retry then goes through. The first
+connect to a freshly-selected world (login or world hop) pauses for about a
+second while this happens; worlds you leave are un-aliased again, and a hard cap
+limits how many can ever be present at once, so the DNS slowdown cannot come back
+even if the world switcher pings many worlds. This works for any target,
+including private servers. You can check how many are aliased at any time with
+`ifconfig lo0 | grep -c "inet 127"` (subtract 1 for `127.0.0.1`).
+
+Two `~/.rsprox/proxy.properties` values tune this:
+
+- `macos.loopback.max` (default `8`) - the most worlds aliased at once. Lower is
+  gentler on DNS; raise it if you hop among many worlds and want them to stay
+  instant.
+- `macos.loopback.grace.seconds` (default `10`) - how long an idle world stays
+  aliased before being removed.
+
+This behaviour can be turned off by setting `macos.loopback.auto=false` in
+`~/.rsprox/proxy.properties`, in which case you must whitelist the addresses
+yourself with the manual fallback below.
+
+<details>
+<summary>Manual fallback (only needed if you disable the automatic behaviour)</summary>
+
+Note that for custom private server targets, the group id must be changed from
+2 to 3+, where 3 is the first custom target, 4 is the second and so on.
 
 ```bash
 #!/bin/bash
@@ -128,6 +156,8 @@ done
 
 echo "Alias IPs added for worlds $MIN_WORLD_ID..$MAX_WORLD_ID (group $GROUP_ID)."
 ```
+
+</details>
 
 ### Transcribing
 Besides live transcribing which happens on the UI directly, it is possible to

--- a/proxy/src/main/kotlin/net/rsprox/proxy/ProxyService.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/ProxyService.kt
@@ -26,6 +26,9 @@ import net.rsprox.proxy.config.ProxyProperty.Companion.BINARY_WRITE_INTERVAL_SEC
 import net.rsprox.proxy.config.ProxyProperty.Companion.BIND_TIMEOUT_SECONDS
 import net.rsprox.proxy.config.ProxyProperty.Companion.FILTERS_STATUS
 import net.rsprox.proxy.config.ProxyProperty.Companion.JAV_CONFIG_ENDPOINT
+import net.rsprox.proxy.config.ProxyProperty.Companion.MACOS_AUTO_LOOPBACK
+import net.rsprox.proxy.config.ProxyProperty.Companion.MACOS_LOOPBACK_GRACE_SECONDS
+import net.rsprox.proxy.config.ProxyProperty.Companion.MACOS_LOOPBACK_MAX
 import net.rsprox.proxy.config.ProxyProperty.Companion.PROXY_PORT_MIN
 import net.rsprox.proxy.config.ProxyProperty.Companion.RUNELITE_RSPROX_CONNECTION
 import net.rsprox.proxy.config.ProxyProperty.Companion.SELECTED_CLIENT
@@ -40,6 +43,7 @@ import net.rsprox.proxy.filters.DefaultPropertyFilterSetStore
 import net.rsprox.proxy.futures.asCompletableFuture
 import net.rsprox.proxy.http.GamePackProvider
 import net.rsprox.proxy.huffman.HuffmanProvider
+import net.rsprox.proxy.loopback.MacLoopbackAliases
 import net.rsprox.proxy.plugin.DecoderLoader
 import net.rsprox.proxy.rsa.publicKey
 import net.rsprox.proxy.rsa.readOrGenerateRsaKey
@@ -600,7 +604,27 @@ public class ProxyService(
             }
         }
         killAliveProcesses()
+        releaseLoopbackAliases()
         SymbolDictionaryProvider.stop()
+    }
+
+    private fun ensureLoopbackAliases(port: Int) {
+        if (!isLoopbackAliasingEnabled()) return
+        MacLoopbackAliases.registerProxyPort(
+            port,
+            properties.getPropertyOrNull(MACOS_LOOPBACK_MAX) ?: MacLoopbackAliases.DEFAULT_MAX_ALIASES,
+            properties.getPropertyOrNull(MACOS_LOOPBACK_GRACE_SECONDS) ?: MacLoopbackAliases.DEFAULT_GRACE_SECONDS,
+        )
+    }
+
+    private fun releaseLoopbackAliases() {
+        if (!isLoopbackAliasingEnabled()) return
+        MacLoopbackAliases.shutdown()
+    }
+
+    private fun isLoopbackAliasingEnabled(): Boolean {
+        if (!MacLoopbackAliases.isSupported(operatingSystem)) return false
+        return properties.getPropertyOrNull(MACOS_AUTO_LOOPBACK) ?: true
     }
 
     private fun closeActiveChannel(channel: Channel) {
@@ -666,6 +690,7 @@ public class ProxyService(
         }
         this.connections.addSessionMonitor(port, sessionMonitor)
         ClientTypeDictionary[port] = "RuneLite (${operatingSystem.shortName})"
+        ensureLoopbackAliases(port)
         launchJavaProcess(
             port,
             operatingSystem,
@@ -735,6 +760,7 @@ public class ProxyService(
             logger.error(t) { "Unable to bind network port $port for native client." }
             return
         }
+        ensureLoopbackAliases(port)
         val javConfigEndpoint = properties.getProperty(JAV_CONFIG_ENDPOINT)
         val worldlistEndpoint = properties.getProperty(WORLDLIST_ENDPOINT)
         val nativeClientType =

--- a/proxy/src/main/kotlin/net/rsprox/proxy/config/ProxyProperties.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/config/ProxyProperties.kt
@@ -6,10 +6,14 @@ import net.rsprox.proxy.config.ProxyProperty.Companion.APP_WIDTH
 import net.rsprox.proxy.config.ProxyProperty.Companion.BINARY_WRITE_INTERVAL_SECONDS
 import net.rsprox.proxy.config.ProxyProperty.Companion.BIND_TIMEOUT_SECONDS
 import net.rsprox.proxy.config.ProxyProperty.Companion.JAV_CONFIG_ENDPOINT
+import net.rsprox.proxy.config.ProxyProperty.Companion.MACOS_AUTO_LOOPBACK
+import net.rsprox.proxy.config.ProxyProperty.Companion.MACOS_LOOPBACK_GRACE_SECONDS
+import net.rsprox.proxy.config.ProxyProperty.Companion.MACOS_LOOPBACK_MAX
 import net.rsprox.proxy.config.ProxyProperty.Companion.PROXY_PORT_MIN
 import net.rsprox.proxy.config.ProxyProperty.Companion.RUNELITE_RSPROX_CONNECTION
 import net.rsprox.proxy.config.ProxyProperty.Companion.WORLDLIST_ENDPOINT
 import net.rsprox.proxy.config.ProxyProperty.Companion.WORLDLIST_REFRESH_SECONDS
+import net.rsprox.proxy.loopback.MacLoopbackAliases
 import java.nio.charset.Charset
 import java.nio.file.Path
 import java.util.Properties
@@ -89,6 +93,11 @@ public value class ProxyProperties private constructor(
             properties.setValue(BIND_TIMEOUT_SECONDS, 30)
             properties.setValue(WORLDLIST_REFRESH_SECONDS, 5)
             properties.setValue(BINARY_WRITE_INTERVAL_SECONDS, 5 * 60)
+            // Automatically manage lo0 loopback aliases on macOS (no-op on other systems).
+            properties.setValue(MACOS_AUTO_LOOPBACK, true)
+            // Most worlds aliased at once, and how long an idle world stays aliased.
+            properties.setValue(MACOS_LOOPBACK_MAX, MacLoopbackAliases.DEFAULT_MAX_ALIASES)
+            properties.setValue(MACOS_LOOPBACK_GRACE_SECONDS, MacLoopbackAliases.DEFAULT_GRACE_SECONDS)
             // gui
             properties.setValue(APP_THEME, "RuneLite")
             properties.setValue(APP_WIDTH, 800)

--- a/proxy/src/main/kotlin/net/rsprox/proxy/config/ProxyProperty.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/config/ProxyProperty.kt
@@ -13,6 +13,9 @@ public class ProxyProperty<T>(
         val BIND_TIMEOUT_SECONDS = ProxyProperty("bind.timeout.seconds", IntProperty)
         val WORLDLIST_REFRESH_SECONDS = ProxyProperty("worldlist.refresh.seconds", IntProperty)
         val BINARY_WRITE_INTERVAL_SECONDS = ProxyProperty("binary.write.interval.seconds", IntProperty)
+        val MACOS_AUTO_LOOPBACK = ProxyProperty("macos.loopback.auto", BooleanProperty)
+        val MACOS_LOOPBACK_MAX = ProxyProperty("macos.loopback.max", IntProperty)
+        val MACOS_LOOPBACK_GRACE_SECONDS = ProxyProperty("macos.loopback.grace.seconds", IntProperty)
 
         // gui
         val APP_THEME = ProxyProperty("app.theme", StringProperty)

--- a/proxy/src/main/kotlin/net/rsprox/proxy/loopback/MacLoopbackAliases.kt
+++ b/proxy/src/main/kotlin/net/rsprox/proxy/loopback/MacLoopbackAliases.kt
@@ -1,0 +1,363 @@
+package net.rsprox.proxy.loopback
+
+import com.github.michaelbull.logging.InlineLogger
+import net.rsprox.proxy.config.CONFIGURATION_PATH
+import net.rsprox.proxy.util.OperatingSystem
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.concurrent.thread
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.writeText
+
+/**
+ * Automatically manages loopback (`lo0`) aliases on macOS so the proxy's per-world
+ * loopback addresses (`127.x.x.x`) are reachable without the user having to run the
+ * manual `ifconfig lo0 alias` script.
+ *
+ * Unlike Linux and Windows, macOS only assigns `127.0.0.1` to `lo0` by default and
+ * does not treat the rest of `127.0.0.0/8` as local - every address the client
+ * connects to must be explicitly aliased, which requires root.
+ *
+ * Adding an alias is the only privileged step, and it is confined to a **session-scoped
+ * helper**: the first time an alias is needed RSProx shows a single macOS administrator
+ * prompt that launches a small root helper for the lifetime of that RSProx run. The
+ * helper reconciles `lo0` to a desired-state file RSProx writes (adding/removing
+ * `127.0.0.0/8` aliases only) and removes every alias again the moment RSProx exits or
+ * dies. Nothing is installed, no `sudoers` entry is written, and no standing password-less
+ * root access is left behind.
+ *
+ * Because macOS source-address selection iterates every interface address on each
+ * outbound connection, aliases are added strictly **on demand**: a poller watches
+ * `netstat` for the client trying to reach the proxy (a `SYN_SENT` socket on a proxy
+ * port), so typically only the world currently in use is aliased. A hard cap and idle
+ * grace bound the live count so the system-wide DNS slowdown cannot come back. Keying off
+ * the proxy port means this works for any target, including private servers.
+ */
+public object MacLoopbackAliases {
+    private val logger = InlineLogger()
+    private val lock = Any()
+
+    /** World loopback addresses that should currently be aliased, mapped to last-active time. */
+    private val desired = HashMap<String, Long>()
+
+    /** Ports the proxy listens on; a `SYN_SENT` to one of these is a client connecting through us. */
+    private val proxyPorts = HashSet<Int>()
+    private var pollerThread: Thread? = null
+    private var helperLaunched = false
+    private var lastWritten: Set<String> = emptySet()
+
+    @Volatile
+    private var maxAliases: Int = DEFAULT_MAX_ALIASES
+
+    @Volatile
+    private var graceMillis: Long = DEFAULT_GRACE_SECONDS * 1000L
+
+    private const val POLL_INTERVAL_MS = 300L
+    public const val DEFAULT_MAX_ALIASES: Int = 8
+    public const val DEFAULT_GRACE_SECONDS: Int = 10
+    private val helperScriptFile: Path = CONFIGURATION_PATH.resolve("rsprox-loopback-session.sh")
+    private val desiredFile: Path = CONFIGURATION_PATH.resolve("rsprox-loopback-desired.txt")
+
+    private const val OCTET = "(25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])"
+    private val loopbackRegex = Regex("^127\\.$OCTET\\.$OCTET\\.$OCTET$")
+    private val whitespace = Regex("\\s+")
+
+    public fun isSupported(operatingSystem: OperatingSystem): Boolean {
+        return operatingSystem == OperatingSystem.MAC
+    }
+
+    /**
+     * Registers a proxy port so the poller recognises clients connecting through it,
+     * applies the alias cap and idle grace, launches the session helper (one admin
+     * prompt) if it is not already running, and starts the on-demand poller.
+     */
+    public fun registerProxyPort(
+        port: Int,
+        maxAliases: Int,
+        graceSeconds: Int,
+    ) {
+        runCatchingLogged("register proxy port for loopback aliasing") {
+            synchronized(lock) {
+                this.maxAliases = maxAliases.coerceAtLeast(1)
+                this.graceMillis = graceSeconds.coerceAtLeast(1) * 1000L
+                proxyPorts.add(port)
+                if (!helperLaunched && !launchSessionHelper()) {
+                    logger.error {
+                        "macOS loopback helper was not started; worlds will be unreachable. " +
+                            "Re-open the client to retry, or add the aliases manually (see README)."
+                    }
+                    return@synchronized
+                }
+                startPollerLocked()
+            }
+        }
+    }
+
+    /**
+     * Stops the poller and asks the session helper to remove every alias. The helper also
+     * removes them by itself once this process exits, so cleanup is guaranteed either way.
+     */
+    public fun shutdown() {
+        runCatchingLogged("release loopback aliases") {
+            val thread: Thread?
+            synchronized(lock) {
+                thread = pollerThread
+                pollerThread = null
+                desired.clear()
+                if (helperLaunched) {
+                    // An empty desired set makes the helper drop every alias promptly.
+                    writeDesiredStateLocked()
+                }
+                helperLaunched = false
+            }
+            thread?.interrupt()
+        }
+    }
+
+    private fun startPollerLocked() {
+        if (pollerThread != null) return
+        pollerThread =
+            thread(start = true, isDaemon = true, name = "rsprox-loopback-poller") {
+                while (!Thread.currentThread().isInterrupted) {
+                    try {
+                        pollOnce()
+                    } catch (t: Throwable) {
+                        logger.debug(t) { "Loopback alias poll failed" }
+                    }
+                    try {
+                        Thread.sleep(POLL_INTERVAL_MS)
+                    } catch (_: InterruptedException) {
+                        break
+                    }
+                }
+            }
+    }
+
+    private fun pollOnce() {
+        val ports: Set<Int>
+        synchronized(lock) {
+            if (proxyPorts.isEmpty()) return
+            ports = proxyPorts.toSet()
+        }
+        val output = runCommand(listOf("/usr/sbin/netstat", "-an", "-p", "tcp")) ?: return
+        val active = parseActiveWorldConnections(output, ports)
+        synchronized(lock) {
+            val now = System.currentTimeMillis()
+            // A world the client is trying to reach should be aliased.
+            for (ip in active.connecting) {
+                desired.putIfAbsent(ip, now)
+            }
+            // Keep worlds with live sockets fresh.
+            for (ip in active.all) {
+                if (ip in desired) desired[ip] = now
+            }
+            // Drop worlds idle past the grace period or over the hard cap.
+            val toRemove = computeRemovals(desired, active.all, now, maxAliases, graceMillis)
+            desired.keys.removeAll(toRemove)
+            writeDesiredStateLocked()
+        }
+    }
+
+    private fun writeDesiredStateLocked() {
+        val current = desired.keys.toSet()
+        if (current == lastWritten) return
+        try {
+            Files.createDirectories(desiredFile.parent)
+            val tmp = desiredFile.resolveSibling("${desiredFile.fileName}.tmp")
+            tmp.writeText(current.joinToString("\n"))
+            Files.move(tmp, desiredFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+            lastWritten = current
+        } catch (t: Throwable) {
+            logger.warn(t) { "Unable to write loopback desired-state file" }
+        }
+    }
+
+    /**
+     * Decides which desired aliases to drop this tick: those idle (no live socket) for
+     * longer than [graceMillis], plus the oldest idle ones needed to get back under
+     * [maxAliases]. Worlds with a live socket ([active]) are never removed.
+     */
+    internal fun computeRemovals(
+        desired: Map<String, Long>,
+        active: Set<String>,
+        now: Long,
+        maxAliases: Int,
+        graceMillis: Long,
+    ): Set<String> {
+        val idleOldestFirst = desired.entries.filter { it.key !in active }.sortedBy { it.value }
+        val expired = idleOldestFirst.filter { now - it.value > graceMillis }.map { it.key }
+        val overCapCount = (desired.size - maxAliases).coerceAtLeast(0)
+        val overCap = idleOldestFirst.take(overCapCount).map { it.key }
+        return (expired + overCap).toSet()
+    }
+
+    internal data class ActiveWorldConnections(
+        val all: Set<String>,
+        val connecting: Set<String>,
+    )
+
+    /**
+     * Parses `netstat -an -p tcp` output, returning the world loopback addresses with a
+     * live socket to one of [proxyPorts], and the subset that are mid-connection
+     * (`SYN_SENT`). Filtering by the proxy port - rather than a known world list - means
+     * any target works, including private servers.
+     */
+    internal fun parseActiveWorldConnections(
+        output: String,
+        proxyPorts: Set<Int>,
+    ): ActiveWorldConnections {
+        val all = HashSet<String>()
+        val connecting = HashSet<String>()
+        for (line in output.lineSequence()) {
+            val fields = line.trim().split(whitespace)
+            if (fields.size < 6 || fields[0] != "tcp4") continue
+            val foreign = parseForeign(fields[4]) ?: continue
+            if (foreign.second !in proxyPorts) continue
+            all.add(foreign.first)
+            if (fields[5] == "SYN_SENT") connecting.add(foreign.first)
+        }
+        return ActiveWorldConnections(all, connecting)
+    }
+
+    private fun parseForeign(foreignAddress: String): Pair<String, Int>? {
+        // macOS formats the foreign address as "127.1.44.2.43701" (ip then port).
+        val portSeparator = foreignAddress.lastIndexOf('.')
+        if (portSeparator <= 0) return null
+        val ip = foreignAddress.substring(0, portSeparator)
+        val port = foreignAddress.substring(portSeparator + 1).toIntOrNull() ?: return null
+        if (!isManageable(ip)) return null
+        return ip to port
+    }
+
+    private fun isManageable(address: String): Boolean {
+        return loopbackRegex.matches(address) && address != "127.0.0.1"
+    }
+
+    private fun launchSessionHelper(): Boolean {
+        try {
+            Files.createDirectories(CONFIGURATION_PATH)
+            // Start from a clean desired set so a fresh helper does not inherit stale state.
+            desired.clear()
+            lastWritten = emptySet()
+            desiredFile.writeText("")
+            helperScriptFile.writeText(sessionHelperScript())
+            val pid = ProcessHandle.current().pid().toString()
+            val shellCommand =
+                "nohup /bin/bash ${shellQuote(helperScriptFile.absolutePathString())} " +
+                    "${shellQuote(pid)} ${shellQuote(desiredFile.absolutePathString())} >/dev/null 2>&1 &"
+            val appleScript =
+                "do shell script \"${escapeForAppleScript(shellCommand)}\" " +
+                    "with prompt \"${escapeForAppleScript(HELPER_PROMPT)}\" with administrator privileges"
+            logger.info { "Requesting administrator approval to manage loopback aliases for this session" }
+            val result = runCommand(listOf("/usr/bin/osascript", "-e", appleScript))
+            if (result == null) {
+                logger.error { "macOS loopback helper launch was declined or failed" }
+                return false
+            }
+            helperLaunched = true
+            return true
+        } catch (t: Throwable) {
+            logger.error(t) { "Unable to launch the macOS loopback helper" }
+            return false
+        }
+    }
+
+    internal fun sessionHelperScript(): String {
+        return """
+            |#!/bin/bash
+            |# RSProx session loopback helper. Runs as root only while RSProx is open.
+            |# Reconciles lo0 127.0.0.0/8 aliases to the desired-state file written by RSProx
+            |# and removes all of them when RSProx exits. Installs nothing, leaves nothing behind.
+            |set -u
+            |ppid="${'$'}{1:-}"
+            |desired_file="${'$'}{2:-}"
+            |[ -n "${'$'}ppid" ] && [ -n "${'$'}desired_file" ] || exit 2
+            |applied=" "
+            |cleanup() {
+            |  for ip in ${'$'}applied; do
+            |    [ -n "${'$'}ip" ] && /sbin/ifconfig lo0 -alias "${'$'}ip" 2>/dev/null
+            |  done
+            |  exit 0
+            |}
+            |trap cleanup EXIT INT TERM
+            |valid() {
+            |  echo "${'$'}1" | /usr/bin/grep -Eq '^127\.(25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])){2}${'$'}'
+            |}
+            |while kill -0 "${'$'}ppid" 2>/dev/null; do
+            |  d=" "
+            |  if [ -f "${'$'}desired_file" ]; then
+            |    while IFS= read -r ip || [ -n "${'$'}ip" ]; do
+            |      [ -n "${'$'}ip" ] || continue
+            |      [ "${'$'}ip" = "127.0.0.1" ] && continue
+            |      valid "${'$'}ip" || continue
+            |      case "${'$'}d" in *" ${'$'}ip "*) ;; *) d="${'$'}d${'$'}ip " ;; esac
+            |    done < "${'$'}desired_file"
+            |  fi
+            |  for ip in ${'$'}d; do
+            |    case "${'$'}applied" in *" ${'$'}ip "*) ;; *)
+            |      /sbin/ifconfig lo0 alias "${'$'}ip" 2>/dev/null && applied="${'$'}applied${'$'}ip " ;;
+            |    esac
+            |  done
+            |  new=" "
+            |  for ip in ${'$'}applied; do
+            |    [ -n "${'$'}ip" ] || continue
+            |    case "${'$'}d" in
+            |      *" ${'$'}ip "*) new="${'$'}new${'$'}ip " ;;
+            |      *) /sbin/ifconfig lo0 -alias "${'$'}ip" 2>/dev/null ;;
+            |    esac
+            |  done
+            |  applied="${'$'}new"
+            |  /bin/sleep 0.3
+            |done
+            |# Parent exited; the EXIT trap removes every alias we added.
+            |
+            """.trimMargin()
+    }
+
+    private fun shellQuote(value: String): String {
+        return "'" + value.replace("'", "'\\''") + "'"
+    }
+
+    private fun escapeForAppleScript(value: String): String {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"")
+    }
+
+    private inline fun <T> runCatchingLogged(
+        action: String,
+        block: () -> T,
+    ): T? {
+        return try {
+            block()
+        } catch (t: Throwable) {
+            logger.error(t) { "Unable to $action" }
+            null
+        }
+    }
+
+    private fun runCommand(command: List<String>): String? {
+        return try {
+            val process =
+                ProcessBuilder(command)
+                    .redirectErrorStream(true)
+                    .start()
+            val output = process.inputStream.bufferedReader().readText()
+            val exit = process.waitFor()
+            if (exit != 0) {
+                logger.debug { "Command ${command.first()} exited with $exit: ${output.trim()}" }
+                null
+            } else {
+                output
+            }
+        } catch (t: Throwable) {
+            logger.debug(t) { "Unable to run command $command" }
+            null
+        }
+    }
+
+    private const val HELPER_PROMPT =
+        "RSProx needs administrator access to add temporary loopback (lo0) network " +
+            "aliases so the game client can reach worlds. They are scoped to 127.0.0.0/8 " +
+            "and removed automatically when RSProx closes."
+}

--- a/proxy/src/test/kotlin/net/rsprox/proxy/loopback/MacLoopbackAliasesTest.kt
+++ b/proxy/src/test/kotlin/net/rsprox/proxy/loopback/MacLoopbackAliasesTest.kt
@@ -1,0 +1,109 @@
+package net.rsprox.proxy.loopback
+
+import net.rsprox.proxy.util.OperatingSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MacLoopbackAliasesTest {
+    @Test
+    fun `session helper reconciles loopback aliases and cleans them up`() {
+        val script = MacLoopbackAliases.sessionHelperScript()
+        assertTrue(script.startsWith("#!/bin/bash\n"), "helper must start with a shebang, got:\n$script")
+        // It only ever touches lo0 loopback aliases, both directions.
+        assertTrue(script.contains("/sbin/ifconfig lo0 alias"))
+        assertTrue(script.contains("/sbin/ifconfig lo0 -alias"))
+        // 127/8 is validated inside the helper so it can never touch a non-loopback address.
+        assertTrue(script.contains("^127\\."))
+        // It watches the parent pid and removes everything on exit (no standing state).
+        assertTrue(script.contains("kill -0"))
+        assertTrue(script.contains("trap cleanup EXIT"))
+    }
+
+    @Test
+    fun `aliasing is only supported on macOS`() {
+        assertTrue(MacLoopbackAliases.isSupported(OperatingSystem.MAC))
+        assertFalse(MacLoopbackAliases.isSupported(OperatingSystem.WINDOWS))
+        assertFalse(MacLoopbackAliases.isSupported(OperatingSystem.UNIX))
+    }
+
+    @Test
+    fun `parses netstat output for connecting and established world addresses`() {
+        val output =
+            """
+            Active Internet connections (including servers)
+            Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)
+            tcp4       0      0  127.0.0.1.49852        127.1.44.2.43701       SYN_SENT
+            tcp4       0      0  127.0.0.1.49860        127.1.45.2.43701       ESTABLISHED
+            tcp4       0      0  127.1.45.2.43701       127.0.0.1.49860        ESTABLISHED
+            tcp4       0      0  192.168.1.5.50122      140.82.121.4.443       ESTABLISHED
+            tcp6       0      0  ::1.7000               ::1.49999              ESTABLISHED
+            """.trimIndent()
+        val parsed = MacLoopbackAliases.parseActiveWorldConnections(output, setOf(43701))
+        // SYN_SENT world is flagged as connecting (to be aliased on demand).
+        assertTrue("127.1.44.2" in parsed.connecting)
+        // Both the connecting and the established world appear in the live set.
+        assertTrue("127.1.44.2" in parsed.all)
+        assertTrue("127.1.45.2" in parsed.all)
+        // The established world is not (re-)connecting.
+        assertFalse("127.1.45.2" in parsed.connecting)
+        // Non-loopback / IPv6 foreign addresses are ignored.
+        assertFalse(parsed.all.any { it.startsWith("140.") || it.startsWith("192.") })
+    }
+
+    @Test
+    fun `only counts connections to the proxy port and handles private-server suffixes`() {
+        // A private-server target uses a different last octet (.3 here); a connection to
+        // an unrelated loopback port must be ignored, while the proxy-port one is caught.
+        val output =
+            """
+            tcp4       0      0  127.0.0.1.50001        127.2.30.3.43702       SYN_SENT
+            tcp4       0      0  127.0.0.1.50002        127.9.9.9.6379         ESTABLISHED
+            """.trimIndent()
+        val parsed = MacLoopbackAliases.parseActiveWorldConnections(output, setOf(43702))
+        // The private-server world reached on the proxy port is detected.
+        assertTrue("127.2.30.3" in parsed.connecting)
+        // The unrelated loopback connection (e.g. redis on 6379) is ignored.
+        assertFalse("127.9.9.9" in parsed.all)
+    }
+
+    @Test
+    fun `eviction drops idle worlds past the grace period but never active ones`() {
+        val now = 100_000L
+        val grace = 10_000L
+        val desired =
+            mapOf(
+                "127.1.1.2" to now - 20_000L, // idle and expired -> remove
+                "127.1.2.2" to now - 2_000L, // idle but within grace -> keep
+                "127.1.3.2" to now - 60_000L, // very stale but currently active -> keep
+            )
+        val active = setOf("127.1.3.2")
+        val removed = MacLoopbackAliases.computeRemovals(desired, active, now, maxAliases = 8, graceMillis = grace)
+        assertTrue("127.1.1.2" in removed)
+        assertFalse("127.1.2.2" in removed)
+        assertFalse("127.1.3.2" in removed)
+    }
+
+    @Test
+    fun `hard cap trims the oldest idle worlds while keeping active ones`() {
+        val now = 100_000L
+        // 6 worlds, cap of 3. Two are active; the four idle ones are within grace.
+        val desired =
+            mapOf(
+                "127.0.0.2" to now - 5_000L, // active
+                "127.0.0.3" to now - 4_000L, // active
+                "127.0.0.4" to now - 9_000L, // idle, oldest
+                "127.0.0.5" to now - 8_000L, // idle
+                "127.0.0.6" to now - 7_000L, // idle
+                "127.0.0.7" to now - 1_000L, // idle, newest
+            )
+        val active = setOf("127.0.0.2", "127.0.0.3")
+        val removed = MacLoopbackAliases.computeRemovals(desired, active, now, maxAliases = 3, graceMillis = 60_000L)
+        // 6 -> 3 means dropping the 3 oldest idle; the newest idle and both active survive.
+        assertEquals(setOf("127.0.0.4", "127.0.0.5", "127.0.0.6"), removed)
+        assertFalse("127.0.0.2" in removed)
+        assertFalse("127.0.0.3" in removed)
+        assertFalse("127.0.0.7" in removed)
+    }
+}


### PR DESCRIPTION
## What
On macOS, only 127.0.0.1 is treated as local, so the per-world loopback
addresses the proxy hands out (127.x.x.x) are unreachable unless aliased on
lo0 - which previously meant running a manual `ifconfig lo0 alias` script.

RSProx now manages these aliases itself.

## Privilege model (no sudoers, nothing installed)
Adding a loopback alias requires root, but that is the only privileged step and
it is confined to a session-scoped helper:

- The first time an alias is needed, a single macOS administrator prompt starts
  a small root helper for the lifetime of that RSProx run.
- The helper only ever reconciles lo0 to a desired-state file RSProx writes,
  scoped strictly to 127.0.0.0/8, and removes every alias again when RSProx
  exits or is killed.
- Nothing is installed, no `sudoers` entry is written, and no standing
  password-less root access is left behind. Quitting and relaunching prompts
  once more.

## On-demand aliasing
macOS scans every interface address on each outbound connection, so keeping
many aliases present at once slows DNS down system-wide. Aliasing is therefore
done strictly on demand:

- An unprivileged `netstat` poller spots the client trying to reach the proxy
  (a `SYN_SENT` socket on a proxy port), so typically only the world currently
  in use is aliased; the client's own retry then connects (~1s on first reach).
- Idle worlds are un-aliased after a grace period, and a hard cap bounds how
  many are ever present at once, so the DNS slowdown can't come back.
- It keys off the proxy port rather than a world list, so it works for any
  target, including private servers.

## Config (proxy.properties)
- `macos.loopback.auto` (default true) - enable/disable
- `macos.loopback.max` (default 8) - hard cap on simultaneous aliases
- `macos.loopback.grace.seconds` (default 10) - idle eviction delay

The old manual script remains documented as a fallback. Includes unit tests for
the netstat parsing, port/private-server filtering, the eviction/cap logic, and
the session helper script.
